### PR TITLE
To expose CERIF vocabularies

### DIFF
--- a/vocab/.htaccess
+++ b/vocab/.htaccess
@@ -1,0 +1,32 @@
+# Turn off MultiViews
+Options -MultiViews
+
+# Directive to ensure *.rdf files served as appropriate content type,
+# if not present in main apache config
+AddType application/rdf+xml .rdf
+
+# Rewrite engine setup
+RewriteEngine On
+
+# Rewrite rule to serve HTML content from the vocabulary URI if requested
+#RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+xml)
+#RewriteCond %{HTTP_ACCEPT} text/html [OR]
+#RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml [OR]
+#RewriteCond %{HTTP_USER_AGENT} ^Mozilla/.*
+#RewriteRule (.*) html/$1.html [R=303]
+
+# Rewrite rule to serve XML content from the vocabulary URI if requested
+RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/xml|application/xml)
+RewriteCond %{HTTP_ACCEPT} text/xml [OR]
+RewriteCond %{HTTP_ACCEPT} application/xml
+RewriteRule (.*) xml/$1.xml [R=303]
+
+# Rewrite rule to serve RDF/XML content from the vocabulary URI if requested application/rdf+xml
+RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+RewriteRule (.*) rdf/$1.rdf [R=303]
+
+# default response
+# ----------------
+
+# Rewrite rule to serve the RDF/XML content from the vocabulary URI by default
+RewriteRule (.*) rdf/$1.rdf [R=303]

--- a/vocab/rdf/ActivityFinanceCategories.rdf
+++ b/vocab/rdf/ActivityFinanceCategories.rdf
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>c855b95d-bf01-44eb-a1f3-17b0f0901599</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Finance Categories</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The type of cost of an activity.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Facility"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Equipment"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Technician"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Travel"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#StaffingExisting"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#StaffingNew"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Consumables"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#OtherNon-Staffing"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Payment-To-Partner"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Estates"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#IndirectCosts"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories#fECBalancingAmount"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Facility">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>cf7799e7-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Facility</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of Facility (also Research Facility) is physically (cfFacil) and logically (cfFacility) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Facil), organisations (cfOrgUnit_Facil), classification systems (cfFacil_Class), projects (cfProj_Facil). In the physical CERIF data model, the classification of types for facility happens with the cfFacil_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning facility types to facility records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A facility is a space or equipment necessary for conducting research (CERIF Entity). The full economic cost associated with the running of the institutional research facilities and equipment used in an activity (Activity Finance Category). The specification, procurement and installation of a facility (Activity Subtype).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; http://www.jcpsg.ac.uk/guidance/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Equipment">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>cf7799e8-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Equipment</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of equipment is physically (cfEquip) and logically (cfEquipment) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Equip), organisations (cfOrgUnit_Equip), classification systems (cfEquip_Class), projects (cfProj_Equip). In the physicial CERIF data model, the classification of types for equipment happens with the cfEquip_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning equipment types to equipment records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Equipment is an instrumentality needed for undertaking or to perform a service (CERIF Entity). The costs associated with the purchase of equipment normally above a price threshold, e.g 1.000 GBP (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=equipment; RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Technician">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>8adcdf20-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Technician</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, technician is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Technician" identified by its cfClassificationIdentifier (a uuid) and reused inlink entities. (CERIF Task Group) A permanent Research staff. (RMAS project)</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A technician is someone known for high skill in some intellectual or artistic technique.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=technician</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Travel">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>fe3ef479-0a35-4b3e-93e8-f54800c98857</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Travel</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The costs associated with travel and subsistence (Activity Finance Category). A physical networking activity normally associated with a single or short series of visits (Activity Subtypes).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#StaffingExisting">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>77a49137-eb32-4a30-9fff-14ce3eb4413f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Staffing Existing</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The costs associated with staff under an existing employment contract including salary and employer tax and pension contributions (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#StaffingNew">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>f81be4da-59bb-4718-949a-6e47b0fa2868</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Staffing New</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The costs associated with staff specifically employed to work on the activity (i.e. additional staff) including salary and employer tax and pension contributions (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Consumables">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>fa67d8ad-46eb-499a-9b9b-2b681b3d9485</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Consumables</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The costs associated with small cost items, e.g. a office stationary, software (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#OtherNon-Staffing">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>5845512f-64ce-4cbe-b4c7-4c8794ab0242</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Other Non-Staffing</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The costs associated with any other directly incurred items (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Payment-To-Partner">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>dd9bb430-17b3-4064-bd1f-528237bd4e48</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Payment-To-Partner</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funding allocated from the funder to project partner, e.g. funds received from the funder by the co-ordinator on behalf of the partners (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#Estates">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>fb8a8939-0659-4cdf-b186-f8430566e845</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Estates</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The full economic cost associated with the running of the institutional physical estate (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.jcpsg.ac.uk/guidance/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#IndirectCosts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>6d81aa21-e667-4778-bc97-c59e0cc3fa18</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Indirect Costs</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The full economic cost associated with the other indirect costs associated with research, e.g. a proportion of HR, Finance, IT, Library, etc. ((Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.jcpsg.ac.uk/guidance/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategories#fECBalancingAmount">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategories"/>
+<dc:identifier>b2aeb46d-3ae2-4df6-aaad-079a339da9d2</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">fEC Balancing Amount</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The difference between the full economic costs of an activity and the budget/income/expenditure, e.g. for an 80%-funded activity of 50.000 this would be the 10.000 amount not received from the funder (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivityFinanceCategoryAmounts.rdf
+++ b/vocab/rdf/ActivityFinanceCategoryAmounts.rdf
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>63468e45-3055-4ba8-b644-6262c96f62bd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Finance Category Amounts</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The income or expenditure (actual, committed or budgeted) against a finance category for the activity (Research project).</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Income-Budget"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Expenditure-Budget"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Income-Commitment"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Expenditure-Commitment"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Income-Actual"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Expenditure-Actual"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Income-Budget">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts"/>
+<dc:identifier>7655a603-a4d7-4b92-8c87-d7e767d2c7a7</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Income-Budget</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The amount of income expected from the funder for an activity, e.g the amount awarded by the funder (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Expenditure-Budget">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts"/>
+<dc:identifier>d2c2d808-bd02-4ffc-8a76-76c3d0c9cc1f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Expenditure-Budget</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The amount of expected expenditure necessary to undertake the activity, e.g. the full economic cost (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Income-Commitment">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts"/>
+<dc:identifier>df1c9f14-6b87-43a1-9a5a-2d0ade88ad0b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Income-Commitment</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The amount of income expected from the funder for an activity but not yet received (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Expenditure-Commitment">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts"/>
+<dc:identifier>8db551b3-e630-48a0-9164-d177f4ec3602</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Expenditure-Commitment</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The amount of expenditure committed but not yet spent, e.g an order placed but not yet paid for ((Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Income-Actual">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts"/>
+<dc:identifier>df27417c-bb3c-4881-9a46-cc6403b2ca39</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Income-Actual</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The amount of actual income received from the funder for an activity (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts#Expenditure-Actual">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFinanceCategoryAmounts"/>
+<dc:identifier>fe050c5b-2760-4c67-b5b6-6252257b7c61</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Expenditure-Actual</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The amount of actual expenditure on an activity, e.g. the cost incurred in undertaking the research (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivityFundingTypes.rdf
+++ b/vocab/rdf/ActivityFundingTypes.rdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFundingTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>a620795c-7015-482e-bdba-43a761b337a1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Funding Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The types of funding mechanism.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFundingTypes#Award"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFundingTypes#Grant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityFundingTypes#Contract"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFundingTypes#Award">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFundingTypes"/>
+<dc:identifier>17273adf-2529-49c3-a40a-21712d67128c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Award</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funding mechanism where discretionary funds are awarded based on an achievement (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFundingTypes#Grant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFundingTypes"/>
+<dc:identifier>4e664be9-100d-481c-b60f-b62a94078bac</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funding mechanism where a proposed activity is submitted for consideration and where the funding is approved (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityFundingTypes#Contract">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityFundingTypes"/>
+<dc:identifier>125a3e36-a300-449f-abfa-11178d87ba63</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contract</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funding mechanism where a proposed activity is submitted for consideration and where the funding is approved and will be allocated on successful delivery of the proposed outputs (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivityOutputContributions.rdf
+++ b/vocab/rdf/ActivityOutputContributions.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityOutputContributions">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>ad87a6e2-5093-4550-86da-ead48cc3f385</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Output Contributions</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in e.g. the cfProject_ResultPublication; cfProject_ResultPatent; cfProject_ResultProduct; cfProject_Event cflink entity, being thus an activity output contribution.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityOutputContributions#Relation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityOutputContributions#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityOutputContributions"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivityStatuses.rdf
+++ b/vocab/rdf/ActivityStatuses.rdf
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af93a-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Statuses</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfProject_Classification link entity, being thus Activity states.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Conceptualised"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Internal-Reviewed"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Submitted"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#NotSubmitted"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Awarded"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Rejected"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#AssumedUnsuccessful"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Withdrawn"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses#Closed"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Conceptualised">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>8dc4b088-6e93-4d3a-ab67-60c0d287868b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conceptualised</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The definition of a planned activity is being developed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Internal-Reviewed">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>edb73a76-2b48-4eca-991e-1b0b6fbe524a</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Internal-Reviewed</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The definition of a planned activity has been sucessfully reviewed including for example a peer review, ethical review, health and safety review, etc. If not sucessfully reviewed, then the proposal needs adjustment for internal re-review or might change status to not submitted.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Submitted">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>20a14a62-85b2-42fe-bd46-d9f07a752abc</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Submitted</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The proposed activity has been submitted to the proposed funder for consideration.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#NotSubmitted">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>444ababa-bfe8-42fc-af0c-15464545ef98</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Not Submitted</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The proposed activity has not been and is not expected to be submitted to a funder for consideration.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Awarded">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>eda2b2e0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Awarded</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The state of awarded is to give as judged due or on the basis of merit. The funder has agreed to fund the proposed activity.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://wordnetweb.princeton.edu/perl/webwn?s=Award</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Rejected">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>f97f3ccd-13c0-46ce-9cb3-98ebb58f39fd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Rejected</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funder rejected the proposed activity. The state of refused is to refuse to let have.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project; CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://wordnetweb.princeton.edu/perl/webwn?s=Award</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#AssumedUnsuccessful">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>0bb4df81-4e9a-41ae-947c-5ae3bde26abd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Assumed Unsuccessful</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funder has not (yet) responded although the elapsed time since submission implies that the proposal has not been successful.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Withdrawn">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>bfcdfa1c-6d27-4012-9468-1c91cecbba45</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Withdrawn</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The funder has agreed to fund the proposed activity but the activity will not proceed (e.g. terms of contract are not acceptable, researchers left institution, etc.).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStatuses#Closed">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStatuses"/>
+<dc:identifier>276a4f0c-6729-47df-b8d3-7cd1cb3c7e67</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Closed</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The activity is considered completed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivityStructure.rdf
+++ b/vocab/rdf/ActivityStructure.rdf
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af930-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Structure</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfProject_Project link entity, being thus an activity structure.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure#Builton"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure#Successor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure#Predecessor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure#Cooperation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure#Builton">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure"/>
+<dc:identifier>eda28bc9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Built on</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Built on - is a form of succession - informally expressed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure#Successor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure"/>
+<dc:identifier>eda28bca-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Successor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A successor is someone who, or something which succeeds or comes after.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Successor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure#Predecessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure"/>
+<dc:identifier>eda28bcb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Predecessor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Something that precedes and indicates the approach of something or someone.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityStructure#Cooperation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityStructure"/>
+<dc:identifier>eda2b2d7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Cooperation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A cooperation is the collaborative work on a common enterprise or project.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivitySubtypes.rdf
+++ b/vocab/rdf/ActivitySubtypes.rdf
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>794234b8-25bb-46df-9d26-ae660bca64bc</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Subtypes</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The subtypes of an activity used for more specific or finer grained analysis.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Organisation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Facility"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Networking"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#ResearchProject"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#ContractResearch"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#EarlyCareerResearchProject"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Consultancy"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Commercialisation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#ContinuingProfessionalDevelopment"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Enterprise"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#KTP"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#ProgrammeGrant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Attendance"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Hosting"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#SpecifiedNamedPerson"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#GeneralFellowship"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Travel"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Workshop"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Building"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Collaborative"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#GeneralStudentship"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes#Block-Grant"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Organisation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>cf7799e2-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of organisation is physically (cfOrgUnit) and logically (cfOrganisationUnit) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. person (cfPers_OrgUnit), events (cfOrgUnit_Event), classification systems (cfOrgUnit_Class), projects (cfProj_OrgUnit). In the CERIF vocabulary, we introduce the concept of organisation. In the physical CERIF data model, the classification of types for organisations happens with the cfOrgUnit_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning organisation types to organisation records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organization (or organisation — see spelling differences) is a social group which distributes tasks for a collective goal. The word itself is derived from the Greek word organon, itself derived from the better-known word ergon - as we know `organ` - and it means a compartment for a particular job.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Organization; RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Facility">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>cf7799e7-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Facility</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of Facility (also Research Facility) is physically (cfFacil) and logically (cfFacility) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Facil), organisations (cfOrgUnit_Facil), classification systems (cfFacil_Class), projects (cfProj_Facil). In the physical CERIF data model, the classification of types for facility happens with the cfFacil_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning facility types to facility records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A facility is a space or equipment necessary for conducting research (CERIF Entity). The full economic cost associated with the running of the institutional research facilities and equipment used in an activity (Activity Finance Category). The specification, procurement and installation of a facility (Activity Subtype).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; http://www.jcpsg.ac.uk/guidance/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Networking">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>67f2c93f-37c9-4311-99e7-61d40d53b265</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Networking</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity which brings together either physically or virtually groups of people, normally over a period of time to meet and exchange information and good practice.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#ResearchProject">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>0bd2d47a-8688-4758-a63c-45e76825a0f6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Project</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A project with a specific set of anticipated research outputs to be produced over a specific time-frame.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#ContractResearch">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>c0441e0d-42e4-4dd1-84bc-9cd345b911f5</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contract Research</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A project funded for an expected outcome (normally specified by the funder).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#EarlyCareerResearchProject">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>28de21fc-ab80-49dc-8725-41d033e81028</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Early Career Research Project</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A project undertaken by an early career researcher, for example someone in the first four years of their academic post.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Consultancy">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>f81c03f9-7d15-4f61-90e6-bbb5c38c9a6c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Consultancy</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A specific bounded (time and specification) contribution to an activity.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Commercialisation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>fb837c4d-73da-448c-a554-383d671bb3eb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Commercialisation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity to (or to support) the transfer of resarch outputs or outcomes into the private sector.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#ContinuingProfessionalDevelopment">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>2a527079-481f-491a-8e3a-dbc79b271c48</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Continuing Professional Development</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The support for the career development of Researchers, Research Students or Research Leaders.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Enterprise">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>6ee92d54-322f-4a55-b2c6-4388ad890754</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Enterprise</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The activity to support working with the private sector.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#KTP">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>7b20769e-cbf6-4955-9844-bdb6b1cd2bf6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">KTP</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The specific activity type defined by the technology strategy board of the UK government.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#ProgrammeGrant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>6cad7850-82ea-42d6-9a7c-fbcc6753848e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Programme Grant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A large-scale activity designed to comprise a number of projects.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Attendance">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>1d4e7a48-d5f9-427a-bd16-e5b503967071</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Attendance</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Attending an event (e.g conference).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Hosting">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>6cc796c4-84f4-448c-9018-7efc47197627</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Hosting</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Hosting an event (e.g conference).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#SpecifiedNamedPerson">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>bd95c4c6-7882-400c-bde9-b20df6f4f87e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Specified Named Person</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A fellowship awarded to an individual.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#GeneralFellowship">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>ee8f08de-b0be-4e2b-a90c-63d08433a56d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">General Fellowship</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A fellowship awarded to an institution for which an individual can subsequently apply to.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Travel">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>fe3ef479-0a35-4b3e-93e8-f54800c98857</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Travel</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The costs associated with travel and subsistence (Activity Finance Category). A physical networking activity normally associated with a single or short series of visits (Activity Subtypes).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Workshop">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>33fd9fc9-48b5-41c5-a2f6-b97c6996e432</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Workshop</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A physical or virtual networking activity bringing people together for a single gathering.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Building">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>fe88ae1b-4eaa-43e6-b8df-479cc0609b8b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Building</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The specification, procurement and installation of buildings.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Collaborative">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>37a7dad6-2487-4df8-9b41-d6c6663bba4b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Collaborative</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">(The work undertaken by a person during) a funded research degree which involves an external agency as part of or host to the research work (e.g. a research council collaborative doctoral award).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#GeneralStudentship">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>65c07ebe-0836-49af-be78-82a36a629b30</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">General Studentship</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">(The work undertaken by a person during) a funded research degree.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivitySubtypes#Block-Grant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivitySubtypes"/>
+<dc:identifier>08431e7e-4a62-42e3-80d7-5941126752c1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Block-Grant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">(The work undertaken by a number of people during) a block of funded research degrees (e.g. a research council block-grant partnership).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ActivityTypes.rdf
+++ b/vocab/rdf/ActivityTypes.rdf
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>47c7efda-bb6e-44ad-bfd3-8be5b6b5cd02</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Activity Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The types of Research activity.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes#Project"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes#Conference"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes#Fellowship"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes#Networking"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes#Infrastructure"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes#Studentship"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes#Project">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes"/>
+<dc:identifier>cf7799e1-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of project is physically (cfProj) and logically (cfProject) defined as an entity in an ERM, represented by basic attributes and through maintaining relationships with other entities: projects (cfProj_Proj), classification systems (cfProj_Class), persons (cfProj_Pers), indicators (cfProj_Indic), measurements (cfProj_Meas). In the CERIF vocabulary, we introduce the concept of project. In the physical CERIF data model, the classification of types for projects happens with the cfProj_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning project types to project records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity with a specific set of anticpated outputs to be produced over a speficic time-frame.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes#Conference">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes"/>
+<dc:identifier>909ea9bd-e460-497e-8950-9ad306675ae9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity that brings together people to discuss topics around an agreed theme.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes#Fellowship">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes"/>
+<dc:identifier>d7fe4a84-93a2-46f1-b1fa-165d518fba47</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Fellowship</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An award for an individual allowing to undertake generic or specific research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes#Networking">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes"/>
+<dc:identifier>67f2c93f-37c9-4311-99e7-61d40d53b265</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Networking</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity which brings together either physically or virtually groups of people, normally over a period of time to meet and exchange information and good practice.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes#Infrastructure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes"/>
+<dc:identifier>4af214d4-579f-4396-aef6-9e3ce879c6be</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Infrastructure</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity to develop or maintain equipment, facilities, services or buildings.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ActivityTypes#Studentship">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ActivityTypes"/>
+<dc:identifier>f74a1e84-6c96-4cab-bd51-da931c9f226d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Studentship</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">(The work undertaken by a person during) a funded research degree.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/CERIFEntities.rdf
+++ b/vocab/rdf/CERIFEntities.rdf
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6e0d9af0-1cd6-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Entities</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains defined CERIF concepts such as person, organisation, research infrastructure (being not only a 1:1 representation of the CERIF entities), but even more, e.g. research infrastructure subsumes facilty, equipment and service and output subsumes publication, patent, and product in CERIF.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Person"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Project"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Organisation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Patent"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Product"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Publication"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Funding"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Facility"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Equipment"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Service"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Citation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#CurriculumVitae"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#ElectronicAddress"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#PostalAddress"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Event"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Medium"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Qualification"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#FederatedIdentifier"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Measurement"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Indicator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#Classification"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities#ClassificationScheme"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Person">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e0-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of person is physically (cfPers) and logically (cfPerson) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Pers), qualifications (cfPers_Qual), events (cfPers_Event), classification systems (cfPers_Class), countries (cfPers_Country).In the CERIF vocabulary, we introduce the concept of person. In the physical CERIF data model, the classification of types for persons happens with the cfPers_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning person types to person records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person (plural: persons or people; from Latin: persona, meaning "mask") is a being, such as a human, that has certain capacities or attributes constituting personhood, the precise definition of which is the subject of much controversy.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Person</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Project">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e1-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of project is physically (cfProj) and logically (cfProject) defined as an entity in an ERM, represented by basic attributes and through maintaining relationships with other entities: projects (cfProj_Proj), classification systems (cfProj_Class), persons (cfProj_Pers), indicators (cfProj_Indic), measurements (cfProj_Meas). In the CERIF vocabulary, we introduce the concept of project. In the physical CERIF data model, the classification of types for projects happens with the cfProj_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning project types to project records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity with a specific set of anticpated outputs to be produced over a speficic time-frame.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Organisation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e2-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of organisation is physically (cfOrgUnit) and logically (cfOrganisationUnit) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. person (cfPers_OrgUnit), events (cfOrgUnit_Event), classification systems (cfOrgUnit_Class), projects (cfProj_OrgUnit). In the CERIF vocabulary, we introduce the concept of organisation. In the physical CERIF data model, the classification of types for organisations happens with the cfOrgUnit_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning organisation types to organisation records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organization (or organisation — see spelling differences) is a social group which distributes tasks for a collective goal. The word itself is derived from the Greek word organon, itself derived from the better-known word ergon - as we know `organ` - and it means a compartment for a particular job.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Organization; RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Patent">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e3-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Patent</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of patent is physically (cfResPat) and logically (cfResultPatent) defined as an entity in an ERM, described through basic attributes and through In the CERIF vocabulary, we introduce the concept of patent. In the physical CERIF data model, the classification of types for patents happens with the cfResPat_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning patent types to patent records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A patent ( /ˈpætənt/ or /ˈpeɪtənt/) is a form of intellectual property. It consists of a set of exclusive rights granted by a sovereign state to an inventor or their assignee for a limited period of time in exchange for the public disclosure of an invention.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Patent</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Product">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e4-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Product</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of product is physically (cfResProd) and logically (cfResultProduct) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_ResProd), organisations (cfOrgUnit_ResProd), classification systems (cfResProd_Class), projects (cfProj_ResProd). "The entity product in CERIF has often caused confusion, it was maybe not stressed enough, that a cerif product is considered a result in general, achieved through some effort - and not at all is it a commercial or a physical product only. It was intended also to represent i.e. software or 'research data'. The Australian National Data Services aims at collecting definitions for clarifiying the concept of ""research data"". In CERIF, cfResProd (cfResultProduct) is an entity in the ERM. In the CERIF vocabulary, we introduce the concept of product. In the physical CERIF data model, the classification of types for products happens with the cfProduct_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning product types to product records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the cfResultProduct (cfResProd) entity is meant conceptually to represent research output, such as an artefact, a device, a performance, an exhibition.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/product</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Publication">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e5-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Publication</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of publication is physically (cfResPubl) and logically (cfResultPublication) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_ResPubl), organisations (cfOrgUnit_ResPubl), classification systems (cfResPubl_Class), projects (cfProj_ResPubl). "In CERIF, cfResPubl (cfResultPublication) is an entity in the ERM. In the CERIF vocabulary, we introduce the concept of publication. Behind the publication concept in research there are moslty peer-reviewed publications (journal articles, conference articles). More and more, there are also other publication types of interest in the scientific domain, so-called 'Grey Literature', and multiple schemes are available to collect publication types. In the physical CERIF data model, the classification of types for publications happens with the cfResPubl_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning publication types to publication records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Collection of information records that, in combination, represent a full and up-to-date history of research or scholarly published outputs resulting from, or related to, the person's research activities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/1.1.0/contributions/outputs/publications</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Funding">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e6-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funding</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of funding is physically (cfFund) and logically (cfFunding) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Fund), organisations (cfOrgUnit_Fund), classification systems (cfRund_Class), projects (cfProj_Fund). In the CERIF vocabulary, we introduce the concept of funding. In the physical CERIF data model, the classification of types for funding happens with the cfFund_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning funding types to funding records.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funding is an amount of money or an inkind equivalent value.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Facility">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e7-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Facility</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of Facility (also Research Facility) is physically (cfFacil) and logically (cfFacility) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Facil), organisations (cfOrgUnit_Facil), classification systems (cfFacil_Class), projects (cfProj_Facil). In the physical CERIF data model, the classification of types for facility happens with the cfFacil_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning facility types to facility records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A facility is a space or equipment necessary for conducting research (CERIF Entity). The full economic cost associated with the running of the institutional research facilities and equipment used in an activity (Activity Finance Category). The specification, procurement and installation of a facility (Activity Subtype).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; http://www.jcpsg.ac.uk/guidance/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Equipment">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e8-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Equipment</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of equipment is physically (cfEquip) and logically (cfEquipment) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Equip), organisations (cfOrgUnit_Equip), classification systems (cfEquip_Class), projects (cfProj_Equip). In the physicial CERIF data model, the classification of types for equipment happens with the cfEquip_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning equipment types to equipment records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Equipment is an instrumentality needed for undertaking or to perform a service (CERIF Entity). The costs associated with the purchase of equipment normally above a price threshold, e.g 1.000 GBP (Activity Finance Category).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=equipment; RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Service">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>cf7799e9-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Service</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of serive is physically (cfSrv) and logically (cfService) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Srv), organisations (cfOrgUnit_Srv), classification systems (cfSrv_Class), projects (cfProj_Srv). In the CERIF vocabulary, we introduce the concept of service. In the physical CERIF data model, the classification of types for service happens with the cfSrv_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning service types to service records."</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A service is an exchange for money or other commodities where an enduser receives support from a supplier.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Citation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>68aa07f0-34c9-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Citation</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the citation entity is used for publication references (citations) to outside of the current information system. Otherwise, citation counts may be deduced from physical publication-publication relationships, i.e. cfResPubl_ResPubl (physical) or cfResultPublication_cfResultPublication (logical) and stored as a measurement cfResPubl_Meas (cfResultPublication_Measurement).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A citation is an acknowledgment, credit, reference, mention, quotation (a short note recognizing a source of information or of a quoted passage).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=citation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#CurriculumVitae">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>68aa07f1-34c9-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Curriculum Vitae</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the CV entity is used for curriculum vitae information references.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A curriculum vitae (cv) is a summary of your academic and work history.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=cv</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#ElectronicAddress">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>68aa07f2-34c9-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Electronic Address</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of electronic address is physically (cfEAddr) and logically (cfElectronicAddress) defined as an entity in the ERM, described through basic attributes and through semantically neutral relationships with persons (cfPers_EAddr), organisations (cfOrgUnit_EAddr), classification systems (cfEAddr_Class).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An electronic address is a computer address, reference ((computer science) the code that identifies where a piece of information is stored).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=address</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#PostalAddress">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>68aa07f3-34c9-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Postal Address</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of physical address is physically (cfPAddr) and logically (cfPhysicalAddress) defined as an entity in the ERM, described through basic attributes and through semantically neutral relationships with persons (cfPers_PAddr), organisations (cfOrgUnit_PAddr), classification systems (cfPAddr_Class).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An address is the place where a person or organization can be found or communicated with.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=address</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Event">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>68aa07f4-34c9-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Event</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of event is physically and logically defined as an entity cfEvent in the ERM, described through basic attributes and through semantically neutral relationships e.g. with persons (cfPers_Event), organisations (cfOrgUnit_Event), classification systems (cfEvent_Class).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An event is something that happens at a given place and time.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=event</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Medium">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>a9332fbf-e5a9-430f-8e78-26bc3610dfe3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Medium</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of medium is physically and logically defined as an entity cfMedium in the ERM, described through basic attributes and through semantically neutral relationships e.g. with persons (cfPers_Event), organisations (cfOrgUnit_Event), classification systems (cfEvent_Class).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A means or instrumentality for storing or communicating information</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; MERIL project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=medium</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Qualification">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>68aa07f5-34c9-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Qualification</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of qualification is physically (cfPAddr) and logically (cfPhysicalAddress) defined as an entity in the ERM, described through basic attributes and through semantically neutral relationships with persons (cfPers_Qual) and classification systems (cfQual_Class).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A qualification is an attribute that must be met or complied with and that fits a person for something.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=qualification</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#FederatedIdentifier">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>a1e51365-b7c4-4bdb-bbd1-0530840148be</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Federated Identifier</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the cfFederatedIdentifier entity is an hybrid entity in the sense that it connects the internal world with an outside world, of which we do not know what can be assumed to be known. For consistency, this entity has ist own cfFederatedIdentifier identifier - namely in short cfFedIdId as an ID and primary key (PK). Finally, the entity has the cfInstanceIdentifier as a character, identifying the record for which this federate identifier is required - in short cfFedInstId. These two just introduced identifiers, in sort cfFedIdId, and cfFedIdInstId represent the internal world of the system. However, following the CERIF link entity style, the linked entity identifier is also required; pointing to the outside world, namely this is the cfFedId or cfFederatedIdentifier as such. It can possibly have a role that is applicable with Relation. We assume that currrently the only role appied is "same as", where for future applications it may be useful to have the usual cfClassId/cfClassSchemeId reference optionally available (e.g. for possible constraints such as - the fed-id-link is valid only for a person in the role of an author). However, especially with the CERIF XML, we currently recommend to omit it, because the cfFedId entity is embeded in the base entity and thus, the same-as attribute is implictly known from the structure of the XML record (see examples and specification documents).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A federated identifier supports with additional information sources extractions.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Measurement">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>1cc0fbd8-a160-41df-9af8-d436e6a5296f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Measurement</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the cfMeasurement entity has been introduced in the context of Impact, which in CERIF is an indicator cfIndicator. In CERIF, a measurement can thus be linked to an indicator through the link entity cfIndicator_Measurement (CERIF link entities are neutral in reading directions), incorporating the usual link entity construct, i.e. Semantic Layer references.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A measurement is the dimension, quantity, or capacity determined by measuring.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; MICE project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/measurement</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Indicator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>ed96ef79-f77d-4aaf-8c19-f727bbb49937</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Indicator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the cfIndicator entity has been introduced in the context of Impact. In CERIF, an indicator can be linked to a measurement through the link entity cfIndicator_Measurement (CERIF link entities are neutral in reading directions), incorporating the usual link entity construct, i.e. Semantic Layer references.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An indicator can be defined as something that helps us to understand where we are, where we are going and how far we are from the goal. Therefore it can be a sign, a number, a graphic and so on. It must be a clue, a symptom, a pointer to something that is changing. Indicators are presentations of measurements. They are bits of information that summarize the characteristics of systems or highlight what is happening in a system. A more rigorous definition is given by the International Institute for Sustainable Development (IISD): " An indicator quantifies and simplifies phenomena and helps us understand complex realities. Indicators are aggregates of raw and processed data but they can be further aggregated to form complex indices." Example of traditional indicators or indices used in measuring the social, economic and environmental welfare are: the Gross National Product, the unemployment rates, the price index, the life expectancy (ESEMPIO DI INDICATORE AMBIENTALE)</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M; MICE project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#Classification">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>613b117e-980e-4051-8876-8524cd498caf</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Classification</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the cfClassification (cfClass) entity is of one of the main entities in the Semantic Layer. Its internal identifier cfClassId is used for references from within all CERIF link entities. It has a recursive entity cfClassification_Classification (cfClass_Class) which is formally also a link entity.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/CERIFEntities#ClassificationScheme">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/CERIFEntities"/>
+<dc:identifier>4c93b3b2-d5ff-442c-9b28-4a028305bcf1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Classification Scheme</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the cfClassificationScheme (cfClassScheme) entity is of one of the main entities in the Semantic Layer. Its internal identifier cfClassSchemId is used for references from within all CERIF link entities. It has a recursive entity cfClassificationScheme_ClassificationScheme (cfClassScheme_ClassScheme) which is formally also a link entity. A classification scheme in CERIF is additionally understandable from the underlying context in which the terms are applied (e.g. Activity Structure in cfProj_Proj; Person Employment Types in cfPers_OrgUnit).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF ER-M</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/EducationDomainTerms.rdf
+++ b/vocab/rdf/EducationDomainTerms.rdf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/EducationDomainTerms">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>b0ca7692-7fda-499f-be40-b44a7bc4f7c7</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Education Domain Terms</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfService_Classification link entity, being used as a vocabulary of educational material, e.g. courses.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/EducationDomainTerms#Course"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/EducationDomainTerms#CoursePresentation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/EducationDomainTerms#Course">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/EducationDomainTerms"/>
+<dc:identifier>e88f9cfd-b786-40cb-9163-4718dbb865ff</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Course</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A course text is a type of study text used as a support for students.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/EducationDomainTerms#CoursePresentation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/EducationDomainTerms"/>
+<dc:identifier>300592ee-e671-4054-a852-ab37b0d744c1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Course Presentation</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A course originating in the Education context is considered a type of service, therefore applicable in the cfSrv_Class link entity. Furthermore, a course presentation is considered an event, hence cfEvent_Class. The series of events linked to a service define the temporal manifestation of the service, which is thus</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ElectronicAddressTypes.rdf
+++ b/vocab/rdf/ElectronicAddressTypes.rdf
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ElectronicAddressTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>1227a225-db7a-444d-a74b-3dd4b438b420</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Electronic Address Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfElectronicAddress_Classification link entity, being used as a vocabulary of electronic address types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes#ProfessionalEmail"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes#MobilePhone"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes#Smartphone"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes#Fixedphone"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ElectronicAddressTypes#ProfessionalEmail">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes"/>
+<dc:identifier>35d43364-2160-4b6c-a487-5019458321e8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Professional Email</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ElectronicAddressTypes#MobilePhone">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes"/>
+<dc:identifier>44651010-00b1-4543-ae6f-b5983b704742</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MobilePhone</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ElectronicAddressTypes#Smartphone">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes"/>
+<dc:identifier>abeddcc6-207b-4b9c-9cec-0de22087b728</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Smartphone</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ElectronicAddressTypes#Fixedphone">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ElectronicAddressTypes"/>
+<dc:identifier>341b4fcc-9fe4-4760-a9c8-0f36ffa4d614</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Fixedphone</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/EventTypes.rdf
+++ b/vocab/rdf/EventTypes.rdf
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/EventTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>e489092b-82a9-4c24-a357-d94dc49eec9b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Event Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfEvent_Classification link entity, being thus event types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/EventTypes#Conference"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/EventTypes#Workshop"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/EventTypes#Conference">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/EventTypes"/>
+<dc:identifier>909ea9bd-e460-497e-8950-9ad306675ae9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity that brings together people to discuss topics around an agreed theme.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/EventTypes#Workshop">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/EventTypes"/>
+<dc:identifier>33fd9fc9-48b5-41c5-a2f6-b97c6996e432</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Workshop</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A physical or virtual networking activity bringing people together for a single gathering.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/FunderTypes.rdf
+++ b/vocab/rdf/FunderTypes.rdf
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>7e21f287-2c00-443b-ae61-fd9ed9e71333</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funder Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The types of funding organisations defined by HESA: http://www.ref.ac.uk/media/ref/content/subguide/01_12a.pdf (page 11)</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#EUGovernmentBodies(includingEC)"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#EUOther"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#OtherServices"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#UK-basedIndustryCommerce&amp;PublicCorporations"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#ResearchCouncils"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#UK-basedCharities"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#UKCentral/LocalGovernmentHealthandHospital"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#EU-basedCharities"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#OtherOverseas"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#EU-basedIndustry"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#EUCommerce&amp;PublicCorporations"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#Non-EU-basedIndustry"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#Non-EU-basedCommerce&amp;PublicCorporations"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#Non-EU-basedCharities"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#OtherSources"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#ResearchDonations"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#Institution-based"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#KTPGrants"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#Non-EUOther"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#UK-basedGovernmentBodies"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FunderTypes#UKOtherSources"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#EUGovernmentBodies(includingEC)">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>3a48310a-fb4a-4177-bb92-cf1aeb0efebb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">EU Government Bodies (including EC)</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from all government bodies operating in the EU, which includes the European Commission but excludes bodies in the UK.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#EUOther">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>c54a63e9-d59d-4bf9-9b81-23b538de8fd6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">EU Other</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">EU-based non-competitive charities and any other EU income that cannot otherwise be allocated more specifically.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#OtherServices">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>0e737bcb-2fec-4c40-90f7-f9aefd8dac8f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Other Services</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Income services that cannot otherwise be allocated more specifically.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#UK-basedIndustryCommerce&amp;PublicCorporations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>dd8df2e3-c481-452f-b9c9-6e426386017f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UK-based Industry Commerce &amp; Public Corporations</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from industrial and commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating in the UK.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#ResearchCouncils">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>032fcb89-8340-4fe3-a5e4-b1191cf6bc31</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Councils</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The sources of income from BBSRC, MRC, NERC, EPSRC, ESRC, AHRC, STFC, The Royal Society, British Academy, The Royal Society of Edinburgh</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#UK-basedCharities">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>874653df-8ced-4ae6-a8ed-449c42f18082</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UK-based Charities</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from all charitable foundations, charitable trusts etc., based in the UK which are registered with the Charities Commission exempt Research Counculs, central government bodies/local authorities, health &amp; hospital authorities. Those organisations recognised as charities by the Office of the Scottish Charity Regulator (OSCR) in Scotland.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#UKCentral/LocalGovernmentHealthandHospital">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>3093abcb-c0d7-4cb7-a5a6-82f40e798811</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UK Central / Local Government Health and Hospital</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from UK central government bodies, UK local authorities and UK health and hospital authorities, except Research Councils and UK public corporations. This should include government departments, and other organisations (including registered charities) financed from central government funds. Research grants and contracts income from non-departmental public bodies (NDPBs), including the British Council, should be included under this column.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#EU-basedCharities">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>bf682b89-0ce7-4fdc-ac67-35bfd2be436e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">EU-based Charities</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from an EU body with exclusively charitable purposes consistent with the definition set out in the Charities Act 2006 and which exists for the public benefit in a manner which is consistent with the Public Benefit Guidance published by the Charity Commission for England and Wales (http://www.charitycommission.gov.uk/publicbenefit/publicbenefit.asp ).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#OtherOverseas">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>abb6de22-ad1b-439a-944f-9e90544a2c0f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Other Overseas</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from industrial and commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating from outside the EU.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#EU-basedIndustry">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>b2a4dd0d-2bbb-4089-8826-99894262e7b3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">EU-based Industry</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from industrial companies operating in the EU outside of the UK. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a French subsidiary making the award would be coded EU other, where UK is excluded from the EU.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#EUCommerce&amp;PublicCorporations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>7c32bcd0-0c34-4103-8d10-a3908b041b06</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">EU Commerce &amp; Public Corporations</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating in the EU outside of the UK. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a French subsidiary making the award would be coded EU other, where UK is excluded from the EU.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#Non-EU-basedIndustry">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>46df9200-e355-45e7-84e7-fdda25dc14ac</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Non-EU-based Industry</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from industrial and commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating outside of the EU. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a US subsidiary making the award would be coded Other overseas.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#Non-EU-basedCommerce&amp;PublicCorporations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>b1ec752b-de87-4377-9c28-87b84ac17845</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Non-EU-based Commerce &amp; Public Corporations</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating outside of the EU. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a US subsidiary making the award would be coded Other overseas, i.e. from outside the EU.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#Non-EU-basedCharities">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>92c1c6c0-b3ba-4edf-b34c-bc6ee14bc756</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Non-EU-based Charities</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from a Non-EU body with exclusively charitable purposes consistent with the definition set out in the Charities Act 2006 and which exists for the public benefit in a manner which is consistent with the Public Benefit Guidance published by the Charity Commission for England and Wales (http://www.charitycommission.gov.uk/publicbenefit/publicbenefit.asp). Grants and contracts income from overseas charity bodies operating outside the EU.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#OtherSources">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>5ca5a3e7-70b8-4f39-a480-b4989f67e7da</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Other Sources</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income not to be allocated more specifically. This should include income from other higher education institutions (HEIs).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#ResearchDonations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>8c6c81e3-6efc-49a6-a7a7-5cd13345d50f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Donations</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants received as a Donation.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#Institution-based">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>78e3de8c-ee32-4ec8-8cc0-6b5f664e6ca1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Institution-based</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants allocated by the institution.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#KTPGrants">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>62d67cb9-2fc5-4afb-a95f-582d55ed916b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">KTP Grants</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Income from Knowledge Transfer Partnerships (KTPs) apart from any portion in respect of studentships or tuition fees.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#Non-EUOther">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>94b8e8e8-5279-4bc2-8b15-b96dc3dc7ff5</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Non-EU Other</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Non-EU-based non-competitive charities and any other Non-EU income that cannot otherwise be allocated more specifically.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#UK-basedGovernmentBodies">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>af3b394e-61f3-431d-8a90-f7cb972993e7</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UK-based Government Bodies</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income from all government bodies operating in the UK.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FunderTypes#UKOtherSources">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FunderTypes"/>
+<dc:identifier>ab2e7af8-7043-4533-a60b-9752f28acbdd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UK Other Sources</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Grants and contracts income not covered by other types. This should include income from other higher education institutions (HEIs).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project; HESA</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/FundingSourceDocumentRelations.rdf
+++ b/vocab/rdf/FundingSourceDocumentRelations.rdf
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>c1aef353-5dbb-46a2-86bf-709bb4be3b4d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funding Source Document Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfResultPublication_Funding link entity, being thus funding source document, assuming the funding concept in CERIF subsumes funding programme, tender, call, and not the income as such, which would be a financial means and as such in CERIF be a measurement.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#FundingProgrammeDocument"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#CallDocument"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#TenderDocument"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#GiftDocument"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#FundingProgrammeDocument">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations"/>
+<dc:identifier>eda2b2d9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funding Programme Document</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The initial funding programme document of a funding programme.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#CallDocument">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations"/>
+<dc:identifier>eda2b2da-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Call Document</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The initial call document of a call.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#TenderDocument">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations"/>
+<dc:identifier>eda2b2db-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Tender Document</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The initial tender document of a tender.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations#GiftDocument">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceDocumentRelations"/>
+<dc:identifier>eda2b2dc-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Gift Document</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The initial gift document of a gift.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/FundingSourceTypes.rdf
+++ b/vocab/rdf/FundingSourceTypes.rdf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af93b-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funding Source Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfFund_Classification link entity, being thus Funding source types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes#FundingProgramme"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes#Call"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes#Tender"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes#Gift"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes#InternalFunding"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceTypes#FundingProgramme">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes"/>
+<dc:identifier>eda2b2e6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funding Programme</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A Funding Programme is the source of financial means to a project, programme, equipment, event or any other structured scientific activity. A Funding Programme is managed by a Funding Organisation.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.eurocris.org/Uploads/Web%20pages/members_meetings/200905_-_Athens__Greece/Funding_Program_Workshop._Introduction_-_Geert_van_Grootel.ppt</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceTypes#Call">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes"/>
+<dc:identifier>eda2b2e7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Call</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">no source found</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceTypes#Tender">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes"/>
+<dc:identifier>eda2b2e8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Tender</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A call for tenders from a funder addressing a specific requirement resulting in a number of contracts.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceTypes#Gift">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes"/>
+<dc:identifier>eda2b2e9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Gift</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A gift or a present is the transfer of something without the expectation of receiving something in return. Although gift-giving might involve an expectation of reciprocity, a gift is meant to be free.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Gift</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/FundingSourceTypes#InternalFunding">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/FundingSourceTypes"/>
+<dc:identifier>40d72109-28ba-4110-a3e9-23ecca3bb795</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Internal Funding</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Where the source of funding comes from the institution itself (e.g. a university-wide conference-attendance scheme).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/IdentifierServiceRoles.rdf
+++ b/vocab/rdf/IdentifierServiceRoles.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierServiceRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>5a270628-f593-4ff4-a44a-95660c76e182</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Identifier Service Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfFederatedIdentifier_Service link entity, being thus a vocabulary of roles within the relation of identification service providers, e.g. Issuer.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierServiceRoles#Issuer"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierServiceRoles#Issuer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierServiceRoles"/>
+<dc:identifier>eda2b2e2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Issuer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An issuer is an institution that issues something (securities or publications or currency etc.).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=issuer;</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/IdentifierTypes.rdf
+++ b/vocab/rdf/IdentifierTypes.rdf
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>bccb3266-689d-4740-a039-c96594b4d916</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Identifier Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfFederatedIdentifier_Classification link entity, being thus a vocabulary of current authority identifiers (extensible and meant as a first start).</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#DOI"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#PMCID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#ISI-Number"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#ScopusAffiliationID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#ScopusAuthorID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#ORCID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#INSTID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#STAFFID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#HUSID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#ResearcherID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#UKPRN"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#URI"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#URL"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#HR-ID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#Project-MM-ID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#Repository-ID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#Finance-ID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#CRIS-ID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#DNR"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#ISNI"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#UUID"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#Handle"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes#VATIdentificationNumber"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#DOI">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>31d222b4-11e0-434b-b5ae-088119c51189</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">DOI</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Digital Object Identifier</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRISPool project; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.doi.org/doi_handbook/Glossary.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#PMCID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>56f4fdbc-39a7-42cd-bd35-9d0d8c95f6da</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">PMCID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">PubMed Central ID</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRISPool project; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.research.ucla.edu/ora/training/documents/Nov-10/5.pdf</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#ISI-Number">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>008f9358-61db-46e2-8157-beb55e972aa6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ISI-Number</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ISI Web Of Knowledge Number</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRISPool project; RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#ScopusAffiliationID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>fafa2259-304e-4aa4-8419-f84b9cf6f2eb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ScopusAffiliationID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Scopus Affiliation Identifier</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRISPool project; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.info.sciverse.com/scopus/scopus-in-detail/tools/affiliationidentifier</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#ScopusAuthorID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>24ddadbc-9b33-40c5-9d25-73b055f0183a</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ScopusAuthorID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Scopus Author Identifier</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRISPool project; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.info.sciverse.com/scopus/scopus-in-detail/tools/authoridentifier</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#ORCID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>716bcc9a-c9dd-4b8b-b4ab-6c140e578ec3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ORCID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Open Researcher &amp; Contributor ID</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ORCID is an international, interdisciplinary, open, and not-for-profit organization created for the benefit of all stakeholders, including research institutions, funding organizations, publishers, and researchers to enhance the scientific discovery process and improve collaboration and the efficiency of research funding.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRISPool project; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://about.orcid.org/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#INSTID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>872e7b38-e11b-4b0f-b68b-6c6279c92e53</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">INSTID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HESA Institution Identifier</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The institution identifier of the reporting institution. The institution is identified by two fields, field 2, HESA institution identifier (a four digit number relating to the institution) and field 3, Campus identifier, a single alphanumeric character. The Campus identifier character 'A' will be designated the default for the whole institution.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_collns&amp;task=show_manuals&amp;Itemid=233&amp;r=96011&amp;f=2</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#STAFFID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>c0071785-549a-4379-a2af-d9a978ea3a1e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">STAFFID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HESA Staff Identifier</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The Staff identifier is a unique code allocated to a staff member when they are first entered onto the staff record and, where a member of staff is contracted to work in jobs classified in SOC groups 1,2 or 3, it stays with them for the whole of their career within HE.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/component/option,com_collns/task,show_manuals/Itemid,233/r,08025/f,003/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#HUSID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>68e498fb-c8ee-4a08-a647-b191df5cac39</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HUSID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HESA Student Identifier</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The Student identifier is to be unique to each student. It is intended that the identifier is to be transferred with the student to each institution of higher education he/she may attend. The medium term objective is that the use of this number will allow the accurate tracking of students throughout their life within the sector for which HESA collects data.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.hesa.ac.uk/index.php?option=com_collns&amp;Itemid=233&amp;task=show_manuals&amp;r=96011&amp;f=004</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#ResearcherID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>b4a7caf0-5257-411e-accc-d1ee70d2f701</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ResearcherID</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The ResearcherID by Thomson Reuters.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.researcherid.com/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#UKPRN">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>39436e26-6d68-4b5a-8ba1-d002a979fdea</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UKPRN</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UK Provider Reference Number</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The UK Register of Learning Providers is a 'one-stop' portal to be used by government departments, agencies, learners, and employers to share key information about learning providers. The UKRLP allows providers to update their information in one place and share this across agencies such as the Skills Funding Agency, the Higher Education Statistics Agency (HESA), the Higher Education Funding Council for England (HEFCE) and UCAS. Since provider registration opened on 1st August 2005, the UKRLP has grown to over 25,000 providers. Each of these has been verified against a recognised external source and has been allocated a UK Provider Reference Number (UKPRN). This is the unique identifier used to share information with the UKRLP partner agencies.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ukrlp.co.uk/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#URI">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>f2dc329b-f47e-4876-9ceb-b190c19aca98</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">URI</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Uniform Resource Identifier</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Uniform_resource_identifier</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#URL">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>7f65458e-00de-4eaf-8109-01e517790a2c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">URL</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Uniform Resource Locator</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Uniform_resource_locator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#HR-ID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>ba36c17a-c056-4d7b-aa26-b62bb04cdfc6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HR-ID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The ID as recorded in the HR system.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#Project-MM-ID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>b52eef12-0dca-4496-ae86-9389de0437f6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project-MM-ID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The ID as recorded in the project management system</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#Repository-ID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>c02711cd-7cfb-4b20-ba2e-15c8c1179a05</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Repository-ID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The ID as recorded in the repository.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#Finance-ID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>7916dbe8-9264-4810-92df-7c21ab733338</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Finance-ID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The ID as recorded in the finance system.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#CRIS-ID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>708d9118-c4dd-4813-8ff7-b43bf0a493b0</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CRIS-ID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The ID as recorded in the CRIS.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#DNR">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>e093fb4c-4d5e-4602-8878-22e7dc360c36</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">DNR</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Diari-Number in Sweden.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#ISNI">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>c7e9afa5-02ce-4222-88f8-b717051fed39</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">ISNI</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">International Standard Name Identifier</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The International Standard Name Identifier (ISNI) is an ISO Standard (ISO 27729) whose scope is the identification of Public Identities of parties: that is, the identities used publicly by parties involved throughout the media content industries in the creation, production, management, and content distribution chains. The ISNI system uniquely identifies Public Identities across multiple fields of creative activity. The ISNI provides a tool for disambiguating Public Identities that might otherwise be confused. ISNI is not intended to provide direct access to comprehensive information about a Public Identity but can provide links to other systems where such information is held.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.isni.org/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#UUID">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>e0d3ce71-2d85-4b6b-8103-636276d31c1d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">UUID</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Unique Universal Identifier</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Universally_unique_identifier</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#Handle">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>baaa59e1-745b-46e3-b068-aaa3dae9eef9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Handle</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The Handle System provides efficient, extensible, and secure resolution services for unique and persistent identifiers of digital objects, and is a component of CNRI's Digital Object Architecture. Digital Object Architecture provides a means of managing digital information in a network environment. A digital object has a machine and platform independent structure that allows it to be identified, accessed and protected, as appropriate. A digital object may incorporate not only informational elements, i.e., a digitized version of a paper, movie or sound recording, but also the unique identifier of the digital object and other metadata about the digital object. The metadata may include restrictions on access to digital objects, notices of ownership, and identifiers for licensing agreements, if appropriate.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.handle.net/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/IdentifierTypes#VATIdentificationNumber">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/IdentifierTypes"/>
+<dc:identifier>634197d9-3a2e-4df7-b982-18b41a7e6f24</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">VAT Identification Number</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A value added tax identification number or VAT identification number (VATIN) is an identifier used in many countries, including the countries of the European Union, for value added tax purposes.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/VAT_identification_number</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterEquipmentRelations.rdf
+++ b/vocab/rdf/InterEquipmentRelations.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EquipmentRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>623d2471-8d16-40c9-915a-df496da086be</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Equipment Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfEquipment_Equipment link entity, being thus an inter-equipment relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-EquipmentRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-EquipmentRelations#Relation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EquipmentRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-EquipmentRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EquipmentRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-EquipmentRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterEventRelations.rdf
+++ b/vocab/rdf/InterEventRelations.rdf
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EventRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>ac90d633-8ad6-4c23-b45a-cc4f91309843</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Event Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfEvent_Event link entity, being thus an inter-event relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations#Successor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations#Predecessor"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EventRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EventRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EventRelations#Successor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations"/>
+<dc:identifier>eda28bca-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Successor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A successor is someone who, or something which succeeds or comes after.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Successor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-EventRelations#Predecessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-EventRelations"/>
+<dc:identifier>eda28bcb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Predecessor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Something that precedes and indicates the approach of something or someone.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterFacilityRelations.rdf
+++ b/vocab/rdf/InterFacilityRelations.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-FacilityRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>da0e5a01-c73e-4489-8cf7-917e9efcdad4</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Facility Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfFacility_Facility link entity, being thus an inter-facility relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-FacilityRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-FacilityRelations#Relation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-FacilityRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-FacilityRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-FacilityRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-FacilityRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterOrganisationalStructure.rdf
+++ b/vocab/rdf/InterOrganisationalStructure.rdf
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>cf7772d0-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Organisational Structure</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_OrganisationUnit link entity, being thus an inter-organisational structure.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Member"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Manager"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Auditor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Contractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Supporter"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Funder"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Acquisition"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Takeover"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Stakeholder"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Merger"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Successor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Predecessor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Spin-Off"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Cooperation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Member">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>cb3e0010-1cd7-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Member</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the member role happens e.g. within the relationships person-organisation, person-project; organisation-organisation, that is, the classification term (cfTerm) "Member" identified by its cfClassificationIdentifier (a uuid), and reused with e.g. the cfPerson_OrganisationUnit; cfProject_Person; cfOrganisationUnit_OrganisationUnit relationships. A person can be a member of multiple organisations. An organization can be a member of another organization, or a state that belongs to a group of nations.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A member is anything that belongs to a set or class.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=member</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Manager">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>79a2e340-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Manager</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A manager is someone who controls resources and expenditures.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Auditor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>c9a24a22-d3f2-4b15-aa06-cb512b2f1341</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Auditor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, auditor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Auditor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An official whose job it is to carefully check the accuracy of business records. An auditor can be either an independent auditor unaffiliated with the company being audited or a captive auditor, and some are elected public officials. The term is sometimes synonymous with "comptroller." Auditors are used to ensure that organizations are maintaining accurate and honest financial records and statements.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.investopedia.com/terms/a/auditor.asp#ixzz238Yb6H7h</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Contractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>abf21190-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Supporter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Supporter</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A supporter is someone who supports or champions something.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=supporter</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Funder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.businessdictionary.com/definition/funder.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Acquisition">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Acquisition</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An acquisition is the act of contracting or assuming or acquiring possession of something</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=acquisition</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Takeover">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Takeover</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A takeover is a change by sale or merger in the controlling interest of a corporation.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=takeover</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Stakeholder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Stakeholder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A corporate stakeholder is a party that can affect or be affected by the actions of the business as a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Stakeholder_(corporate)</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Merger">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bc7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Merger</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A merger is a voluntary amalgamation of two firms on roughly equal terms into one new legal entity. Mergers are effected by exchange of the pre-merger stock (shares) for the stock of the new firm. Owners of each pre-merger firm continue as owners, and the resources of the merging entities are pooled for the benefit of the new entity. If the merged entities were competitors, the merger is called horizontal integration, if they were supplier or customer of one another, it is called vertical integration.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.businessdictionary.com/definition/merger.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Successor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bca-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Successor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A successor is someone who, or something which succeeds or comes after.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Successor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Predecessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bcb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Predecessor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Something that precedes and indicates the approach of something or someone.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Spin-Off">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda28bcc-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Spin-Off</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A spin-out, also known as a spin-off or a starburst, refers to a type of corporate action where a company "splits off" sections of itself as a separate business.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Corporate_spin-off</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure#Cooperation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OrganisationalStructure"/>
+<dc:identifier>eda2b2d7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Cooperation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A cooperation is the collaborative work on a common enterprise or project.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterOutputRelations.rdf
+++ b/vocab/rdf/InterOutputRelations.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OutputRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>a7e0dc90-1be4-4fd9-9ff7-bdfb8a95a1eb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Output Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in e.g. a cfResultPublication_ResultPatent; cfResultPublication_ResultProduct link entity, being thus an inter-output relations. The type of relationships between two outputs (e.g publication and data).</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OutputRelations#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-OutputRelations#Builton"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OutputRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OutputRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-OutputRelations#Builton">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-OutputRelations"/>
+<dc:identifier>eda28bc9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Built on</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Built on - is a form of succession - informally expressed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterPatentRelations.rdf
+++ b/vocab/rdf/InterPatentRelations.rdf
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PatentRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>50772538-d92f-4048-ae76-93e1659afc8b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Patent Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfResultPatent_ResultPatent link entity, being thus an inter-patent relation.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations#Successor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations#Predecessor"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PatentRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PatentRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PatentRelations#Successor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations"/>
+<dc:identifier>eda28bca-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Successor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A successor is someone who, or something which succeeds or comes after.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Successor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PatentRelations#Predecessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PatentRelations"/>
+<dc:identifier>eda28bcb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Predecessor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Something that precedes and indicates the approach of something or someone.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterProductRelations.rdf
+++ b/vocab/rdf/InterProductRelations.rdf
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ProductRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>f5c75446-de28-4c4b-8739-8f6223a09e88</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Product Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfResultProduct_ResultProduct link entity, being thus an inter-product relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations#Successor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations#Predecessor"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ProductRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ProductRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ProductRelations#Successor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations"/>
+<dc:identifier>eda28bca-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Successor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A successor is someone who, or something which succeeds or comes after.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Successor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ProductRelations#Predecessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-ProductRelations"/>
+<dc:identifier>eda28bcb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Predecessor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Something that precedes and indicates the approach of something or someone.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterPublicationRelations.rdf
+++ b/vocab/rdf/InterPublicationRelations.rdf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PublicationRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af932-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Publication Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfResultPublication_ResultPublication link entity, being thus an inter-publication relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Relation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Derivedfrom"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Successor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Predecessor"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Derivedfrom">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations"/>
+<dc:identifier>eda28bc8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Derived from</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A derivation is the source or origin from which something derives.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=derivation</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Successor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations"/>
+<dc:identifier>eda28bca-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Successor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A successor is someone who, or something which succeeds or comes after.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Successor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-PublicationRelations#Predecessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-PublicationRelations"/>
+<dc:identifier>eda28bcb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Predecessor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Something that precedes and indicates the approach of something or someone.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/InterServiceRelations.rdf
+++ b/vocab/rdf/InterServiceRelations.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ServiceRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>39f413d8-e5ee-409a-95f1-d204b78508b9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inter-Service Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfService_Service link entity, being thus an inter-service relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-ServiceRelations#Part"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/Inter-ServiceRelations#Relation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ServiceRelations#Part">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-ServiceRelations"/>
+<dc:identifier>eda28bc1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Part</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A part is a portion, division, piece, or segment of a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/part</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/Inter-ServiceRelations#Relation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/Inter-ServiceRelations"/>
+<dc:identifier>eda28bc2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Relation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An abstraction belonging to or characteristic of two entities or parts together.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/MediaRelations.rdf
+++ b/vocab/rdf/MediaRelations.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/MediaRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>40d45f50-db4b-449c-b4f6-ae202b220e5a</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Media Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in link entities relating to medium, such as cfOrgUnit_Medium; cfProj_Medium ... (in the function of e.g. Logo).</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/MediaRelations#Logo"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/MediaRelations#Logo">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/MediaRelations"/>
+<dc:identifier>9931ac47-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Logo</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The logo representing an entity, such as organisation, product, project.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/MereotopologicalStructure.rdf
+++ b/vocab/rdf/MereotopologicalStructure.rdf
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+	<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/MereotopologicalStructure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>065bd11e-0f80-4a5e-a695-54bed2e255a5</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Mereotopological Structure</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme implies the CERIF vocabulary terms applicable with intra-entity sturctures - such as Part in e.g. link entities such as cfOrganisationUnit_OrganisationUnit; cfProject_Project.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/MereotopologicalStructure#Acquisition"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/MereotopologicalStructure#Takeover"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/MereotopologicalStructure#Derivedfrom"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/MereotopologicalStructure#Acquisition">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/MereotopologicalStructure"/>
+<dc:identifier>eda28bc3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Acquisition</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An acquisition is the act of contracting or assuming or acquiring possession of something</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=acquisition</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/MereotopologicalStructure#Takeover">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/MereotopologicalStructure"/>
+<dc:identifier>eda28bc4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Takeover</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A takeover is a change by sale or merger in the controlling interest of a corporation.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=takeover</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/MereotopologicalStructure#Derivedfrom">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/MereotopologicalStructure"/>
+<dc:identifier>eda28bc8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Derived from</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A derivation is the source or origin from which something derives.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=derivation</dc:source>
+</rdf:Description>
+</rdf:RDF>
+	

--- a/vocab/rdf/OpenScienceCosts.rdf
+++ b/vocab/rdf/OpenScienceCosts.rdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OpenScienceCosts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>e87469e5-d6bd-458c-b7ef-90e314749c51</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Open Science Costs</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The type of cost allocated to an output in order to make it Open Access or Open Dataset.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OpenScienceCosts#GoldOpenAccess"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OpenScienceCosts#GreenOpenAccess"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OpenScienceCosts#DataStorage"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OpenScienceCosts#GoldOpenAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OpenScienceCosts"/>
+<dc:identifier>98072417-c98b-46dc-99aa-364bb672cd63</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Gold Open Access</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The cost charged by a publisher to make an individual output freely available.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OpenScienceCosts#GreenOpenAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OpenScienceCosts"/>
+<dc:identifier>7cfe736a-73bb-4324-b3dd-34228e5dbe7d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Green Open Access</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The cost of depositing a version of the publication for free public access in a CRIS/institutional repository. Normally this cost will be zero.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OpenScienceCosts#DataStorage">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OpenScienceCosts"/>
+<dc:identifier>59c67182-270e-4ade-8edb-9cdf16d2e1b1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Data Storage</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The cost of depositing a version of the research data for free public access in a CRIS/institutional repository. The cost may not be zero.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationContactDetails.rdf
+++ b/vocab/rdf/OrganisationContactDetails.rdf
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>fee53e30-de3a-421b-80e0-9b3fe3a3c170</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Contact Details</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organisation's electronic and postal contact coordinates. This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_ElectroniAddress or cfOrganisationUnit_PostAddress link entity, being thus organisation contact details.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#Fax"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#Email"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#ProfessionalEmail"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#Skype"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#Twitter"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#Facebook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#LinkedIn"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#Phone"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#PublicAccess"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#CorporateAccess"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#OrganisationLegalPostalAddress"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails#OrganisationFinancialPostalAddress"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#Fax">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>9931ac41-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Fax</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#Email">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>9931ac42-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Email</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#ProfessionalEmail">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>35d43364-2160-4b6c-a487-5019458321e8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Professional Email</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#Skype">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>20476135-bc75-40b4-b5f0-f05543e919c6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Skype</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#Twitter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>95bff29c-338f-4790-80ac-c39ec3bc72f4</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Twitter</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#Facebook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>beb680a9-4504-417f-b444-65ff289c5952</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Facebook</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#LinkedIn">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>48ed3997-8f3b-41bd-94c5-ba37df71c263</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">LinkedIn</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#Phone">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>9931ac44-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Phone</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#PublicAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>9931ac45-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Public Access</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#CorporateAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>9931ac46-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Corporate Access</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#OrganisationLegalPostalAddress">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>3e480ccf-15cd-4e73-bdcc-d0d3c73a405c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Legal Postal Address</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The address to which legal notices may be served.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationContactDetails#OrganisationFinancialPostalAddress">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationContactDetails"/>
+<dc:identifier>e103718b-c1b3-4cfd-ae53-d4b5c1d1fcae</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Financial Postal Address</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The address to which financial queries should be sent</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationFundingRoles.rdf
+++ b/vocab/rdf/OrganisationFundingRoles.rdf
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af937-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Funding Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfOrgUnit_Funding link entity, being thus organisation funding roles.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Contributor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Contact"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Applicant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Issuer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Responsible"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Financier"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Contributor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles"/>
+<dc:identifier>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contributor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CIA project; RMAS Project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Contact">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles"/>
+<dc:identifier>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contact</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The person to be contacted in a particular circumstance (e.g. finance).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contact is a communicative interaction.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contact</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Applicant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles"/>
+<dc:identifier>33551370-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Applicant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An applicant is also called proposer.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Issuer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles"/>
+<dc:identifier>eda2b2e2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Issuer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An issuer is an institution that issues something (securities or publications or currency etc.).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=issuer;</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Responsible">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles"/>
+<dc:identifier>eda2b2e3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Responsible</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A responsible is the agent or cause; worthy of or requiring responsibility or trust; or held accountable.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=responsible;</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationFundingRoles#Financier">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationFundingRoles"/>
+<dc:identifier>eda2b2e4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Financier</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Financier (pronounced /fɪnənˈsɪər/, French: [finɑ̃ˈsje]) is a term for a person who handles typically large sums of money, usually involving money lending, financing projects, large-scale investing, or large-scale money management.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Financier</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationMeasurementRelations.rdf
+++ b/vocab/rdf/OrganisationMeasurementRelations.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationMeasurementRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>aef32e66-d31a-40db-bbd9-d1df96522987</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Measurement Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable with the cfOrganisationUnit_Measurement entity, being thus organisation related measurements, such as e.g. cost center.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationMeasurementRelations#CostCenter"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationMeasurementRelations#CostCenter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationMeasurementRelations"/>
+<dc:identifier>eda2b2e5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Cost Center</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In business, a cost centre is a division that adds to the cost of an organization, but only indirectly adds to its profit. Typical examples include research and development, marketing and customer service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Cost_centre_%28business%29</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationOutputContributions.rdf
+++ b/vocab/rdf/OrganisationOutputContributions.rdf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputContributions">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6b2b7d26-3491-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Output Contributions</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_ResultPublication link entity, being thus an organisation's output contribution.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Reviewer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Author"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Commissioner"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions#ReviewerInstitution"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Host"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Reviewer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions"/>
+<dc:identifier>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reviewer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reviewer is someone who reads manuscripts and judges their suitability for publication.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Author">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions"/>
+<dc:identifier>49815870-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Author</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An author is the person or corporate entity responsible for producing a written work (essay, monograph, novel, play, poem, screenplay, short story, etc.) whose name is printed on the title page of a book or given elsewhere in or on a manuscript or other item and in whose name the work is copyrighted. A work may have two or more joint authors. In library cataloging, the term is used in its broadest sense to include editor, compiler, composer, creator, etc</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_e.cfm#author</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Commissioner">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions"/>
+<dc:identifier>7ef398b3-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Commissioner</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A government administrator, a member of a commission.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_t.cfm#commissioner</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputContributions#ReviewerInstitution">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions"/>
+<dc:identifier>eda2b2d5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reviewer Institution</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reviewer institution is an organization founded and united for a specific purpose where the reviewer has a relationship.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputContributions#Host">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputContributions"/>
+<dc:identifier>eda2d9ff-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Host</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationOutputRoles.rdf
+++ b/vocab/rdf/OrganisationOutputRoles.rdf
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>877161b4-00d2-42c8-a368-aaa35262f3a8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Output Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_ResultPublication link entity, being used as a vocabulary of organisation output roles - different from organisation output contribution.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#Publisher"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#Funder"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#IPRClaim"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#Curator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#AuthorInstitution"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#PublisherInstitution"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles#ExternalOrganisation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#Publisher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>7ef398b2-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Publisher</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person or corporate entity that prepares and issues printed materials for public sale or distribution, normally on the basis of a legal contract in which the publisher is granted certain exclusive rights in exchange for assuming the financial risk of publication and agreeing to compensate the author, usually with a share of the profits.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_t.cfm#publisher</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#Funder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>eda28bc0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.businessdictionary.com/definition/funder.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#IPRClaim">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>eda2b2d0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">IPR Claim</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">1. The rights of creative workers in literary, artistic, industrial and scientific fields which can be protected either by copyright or trademarks, patents, etc. 2. Tangible products of the human mind and intelligence entitled to the legal status of personal property, especially works protected by copyright, inventions that have been patented, and registered trademarks. An idea is considered the intellectual property of its creator only after it has been recorded or made manifest in specific form.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.newcastle.edu.au/service/library/tutorials/infoskills/glossary.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#Curator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>eda2b2d2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Curator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person responsible for the development, care, organization, and supervision of a museum, gallery, or other exhibit space and all the objects stored or displayed in it, a role requiring considerable knowledge and experience when items are selected on the basis of artistic merit or connoisseurship. Also, a person in charge of a special collection, trained to assist users in locating and interpreting its holdings.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/search.cfm</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#AuthorInstitution">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>eda2b2d3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Author Institution</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An author institution is an organization founded and united for a specific purpose where the author has a relationship.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#PublisherInstitution">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>eda2b2d4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Publisher Institution</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A publisher institution is an organization founded and united for a specific purpose where the publisher has a relationship.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationOutputRoles#ExternalOrganisation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationOutputRoles"/>
+<dc:identifier>eda2b2d6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">External Organisation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An external organisation an organization founded and united for a specific purpose that is happening or arising or located outside or beyond some limits or especially surface.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=External; http://wordnetweb.princeton.edu/perl/webwn?s=institution</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationProjectEngagements.rdf
+++ b/vocab/rdf/OrganisationProjectEngagements.rdf
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6b2b7d25-3491-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Project Engagements</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfProject_OrganisationUnit link entity - being thus an organisation's project engagement.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Reviewer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Contractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Subcontractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Coordinator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Participant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Applicant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Commissioner"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Funder"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Inkind-Contributor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Partner"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Sponsor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Stakeholder"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Reviewer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reviewer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reviewer is someone who reads manuscripts and judges their suitability for publication.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Contractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>abf21190-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Subcontractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>b272a660-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subcontractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A subcontractor is someone who enters into a subcontract with the primary contractor.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=subcontractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Coordinator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>c31d3380-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Coordinator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, coordinator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Coordinator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A coordinator is someone whose task is to see that work goes harmoniously.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=coordinator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Participant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>ddc3dd10-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Participant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, participant is a role e.g. in the person-project relationship; that is, the classification term (cfTerm) "Participant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A participant is someone who takes part in an activity</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=participant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Applicant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>33551370-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Applicant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An applicant is also called proposer.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Commissioner">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>7ef398b3-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Commissioner</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A government administrator, a member of a commission.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_t.cfm#commissioner</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Funder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>eda28bc0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.businessdictionary.com/definition/funder.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Inkind-Contributor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>69948e23-7c53-4437-a33e-17c051b9281b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inkind-Contributor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organisation that provides a non-monetary contribution towards an activity (e.g. staff time, use of facilities).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Partner">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>c77f9885-b80d-466a-9097-9768720c0fe1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Partner</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organisation working in collaboration as part of a consortium to undertake an activity. Normally retaining an interest in any IP generated.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Sponsor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>f27bedda-f04c-4d32-a026-d4955bb65227</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Sponsor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organisation that undertakes to ensure the research governance of the activity (used in the UK especially in the Health and Social Services domain).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationProjectEngagements#Stakeholder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationProjectEngagements"/>
+<dc:identifier>eda28bc6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Stakeholder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A corporate stakeholder is a party that can affect or be affected by the actions of the business as a whole.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Stakeholder_(corporate)</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationResearchInfrastructureRoles.rdf
+++ b/vocab/rdf/OrganisationResearchInfrastructureRoles.rdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af93e-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Research Infrastructure Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_Equipment; cfOrganisationUnit_Service, cfOrganisationUnit_Facility link entities, being thus organisation infrastructure roles.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles#Owner"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles#Host"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles#User"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles#Owner">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles"/>
+<dc:identifier>eda2d9fe-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Owner</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles#Host">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles"/>
+<dc:identifier>eda2d9ff-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Host</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles#User">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationResearchInfrastructureRoles"/>
+<dc:identifier>eda2da00-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">User</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OrganisationTypes.rdf
+++ b/vocab/rdf/OrganisationTypes.rdf
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af939-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organisation Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_Classification link entity, being thus organisation types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#AcademicInstitute"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#University"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#UniversityCollege"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#ResearchInstitute"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#StrategicResearchInsitute"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#Company"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#SME"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#Government"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#HigherEducation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#Privatenon-profit"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#Intergovernmental"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#Charity"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes#NationalHealthService"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#AcademicInstitute">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2ec-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Academic Institute</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An academic institution is an educational institution dedicated to education and research, which grants academic degrees.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Academic_institution</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#University">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2ed-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">University</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A university is an institution of higher education and research, which grants academic degrees in a variety of subjects. A university is a corporation that provides both undergraduate education and postgraduate education.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/University</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#UniversityCollege">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2ee-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">University College</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The term "university college" is used in a number of countries to denote college institutions that provide tertiary education but do not have full or independent university status. A university college is often part of a larger university. The precise usage varies from country to country.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/University_college</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#ResearchInstitute">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2ef-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Institute</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A research institute is an establishment endowed for doing research. Research institutes may specialize in basic research or may be oriented to applied research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS;</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Research_institute</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#StrategicResearchInsitute">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2f0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Strategic Research Insitute</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A strategic research institute's core mission is to provide analyses that respond to the needs of decision-makers.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#Company">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2f1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Company</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A company is a form of business organization. In the United States, a company is a corporation—or, less commonly, an association, partnership, or union—that carries on an industrial enterprise." Generally, a company may be a "corporation, partnership, association, joint-stock company, trust, fund, or organized group of persons, whether incorporated or not, and (in an official capacity) any receiver, trustee in bankruptcy, or similar official, or liquidating agent, for any of the foregoing." In English law, and therefore in the Commonwealth realms, a company is a form of body corporate or corporation, generally registered under the Companies Acts or similar legislation. It does not include a partnership or any other unincorporated group of persons.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Company</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#SME">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2f2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">SME</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Small and medium enterprises (also SMEs, small and medium businesses, SMBs, and variations thereof) are companies whose headcount or turnover falls below certain limits. EU Member States traditionally have their own definition of what constitutes an SME, for example the traditional definition in Germany had a limit of 250 employees, while, for example, in Belgium it could have been 100. But now the EU has started to standardize the concept. Its current definition categorizes companies with fewer than 10 employees as "micro", those with fewer than 50 employees as "small", and those with fewer than 250 as "medium".</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Small_and_medium_enterprises; http://ec.europa.eu/enterprise/policies/sme/facts-figures-analysis/sme-definition/index_en.htm</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#Government">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2f3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Government</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A government is the organization, or agency through which a political unit exercises its authority, controls and administers public policy, and directs and controls the actions of its members or subjects.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Government</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#HigherEducation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2f4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Higher Education</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Higher education or post-secondary education refers to a level of education that is provided at academies, universities, colleges, seminaries, institutes of technology, and certain other collegiate- level institutions, such as vocational schools, trade schools, and career colleges, that award academic degrees or professional certifications.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Higher_education</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#Privatenon-profit">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>eda2b2f5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Private non-profit</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An organization that is incorporated under state law and whose purpose is not to make profit, but rather to further a charitable, civic, scientific, or other lawful purpose.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#Intergovernmental">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>13d1fa53-18f0-4bf2-88ca-2d2df474f404</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Intergovernmental</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An intergovernmental organization, sometimes rendered as an international governmental organization and both abbreviated as IGO, is an organization composed primarily of sovereign states (referred to as member states), or of other intergovernmental organizations. Intergovernmental organizations are often called international organizations, although that term may also include international nongovernmental organization such as international non-profit organizations or multinational corporations.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">VOA3R project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Intergovernmental_organization</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#Charity">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>ecaac6d5-b281-4f0a-a6fa-2c155aa51002</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Charity</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A charitable organization is a type of non-profit organization (NPO). It differs from other types of NPOs in that it centers on philanthropic goals (e.g. charitable, educational, religious, or other activities serving the public interest or common good). The legal definition of charitable organization (and of Charity) varies according to the country and in some instances the region of the country in which the charitable organization operates. The regulation, tax treatment, and the way in which charity law affects charitable organizations also varies.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Charitable_organization</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OrganisationTypes#NationalHealthService">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OrganisationTypes"/>
+<dc:identifier>1d9ffa49-8af2-4844-a228-5498846b8da2</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">National Health Service</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Hospitals, trusts and other bodies receiving funding from central governement through the national insurance scheme.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OutputFundingRoles.rdf
+++ b/vocab/rdf/OutputFundingRoles.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputFundingRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af933-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Output Funding Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfResulsPublication_Funding link entity, being thus publication funding roles and e.g. a reference to the funding programe, because the funding concept in CERIF subsumes funding programme, tender, call, and not the income as such, which would be a financial means and as such in CERIF be a measurement.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputFundingRoles#Funder"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputFundingRoles#Funder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputFundingRoles"/>
+<dc:identifier>eda28bc0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.businessdictionary.com/definition/funder.html</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OutputQualityLevels.rdf
+++ b/vocab/rdf/OutputQualityLevels.rdf
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>1332d166-4c65-481b-adde-aac0bdc475a3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Output Quality Levels</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">If a quality level has been assigned to an output, then this is the assessment of the level of quality on the REF scale (http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/)</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels#PendingGrading"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels#4-Star"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels#3-Star"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels#2-Star"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels#1-Star"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels#Unclassified"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels#PendingGrading">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels"/>
+<dc:identifier>19258084-7068-4be1-8cfd-171952060f0c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pending Grading</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An assessment has yet to be made of the quality level of the output.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels#4-Star">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels"/>
+<dc:identifier>f9237eb5-a5c9-433f-887d-e2eac703bc18</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">4-Star</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Quality that is world-leading in terms of originality, significance and rigour.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">REF 2014; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels#3-Star">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels"/>
+<dc:identifier>9e93db57-3349-4bb9-bfba-9481302b4784</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">3-Star</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Quality that is internationally excellent in terms of originality, significance and rigour but which falls short of the highest standards of excellence.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">REF 2014; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels#2-Star">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels"/>
+<dc:identifier>7f1998ce-ddfa-4ece-af02-2eed9a48c8d2</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">2-Star</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Quality that is recognised internationally in terms of originality, significance and rigour.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">REF 2014; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels#1-Star">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels"/>
+<dc:identifier>89644214-e41f-4c30-befb-ab5d9443c08b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">1-Star</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Quality that is recognised nationally in terms of originality, significance and rigour.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">REF 2014; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputQualityLevels#Unclassified">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputQualityLevels"/>
+<dc:identifier>7ea05f8e-bd27-4f33-bfa4-54dfb3e6f905</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Unclassified</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Quality that falls below the standard of nationally recognised work. Or work which does not meet the published definition of research for the purposes of this assessment.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">REF 2014; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OutputResearchInfrastructureRelations.rdf
+++ b/vocab/rdf/OutputResearchInfrastructureRelations.rdf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6df0658e-34bd-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Output Research Infrastructure Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfResultPublication_Equipment; cfResultPublication_Service, cfResultPublication_Facility link entities, being thus output infrastructure relationss.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations#Development"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations#Development">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations"/>
+<dc:identifier>eda2da03-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Development</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/OutputTypes.rdf
+++ b/vocab/rdf/OutputTypes.rdf
@@ -1,0 +1,943 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af938-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Output Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfResultPublication_Classification, cfResultPatent_Classification, cfResultProduct_Classification, cfEvent_Class link entities, being thus output types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Conference"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Book"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#BookReview"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#BookChapterAbstract"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#BookChapterReview"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Inbook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Anthology"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Monograph"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Referencebook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Textbook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Encyclopedia"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Manual"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Otherbook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Journal"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#JournalArticle"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#JournalArticleAbstract"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#JournalArticleReview"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ConferenceProceedings"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ConferenceProceedingsArticle"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Letter"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#LettertoEditor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#PhDThesis"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#DoctoralThesis"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Report"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ShortCommunication"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Poster"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Presentation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Newsclipping"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Commentary"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Annotation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Transliteration"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Translation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#AuthoredBook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#EditedBook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ChapterinBook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ScholarlyEdition"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ConferenceContribution"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#WorkingPaper"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Artefact"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Devicesandproducts"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Performance"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Exhibition"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Patent/publishedpatentapplication"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Composition"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Design"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Researchreportforexternalbody."/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ConfidentialReport(forexternalbody)."/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Software"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Websitecontent"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Digitalorvisualmedia"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Researchdatasetsanddatabases"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Other"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#JournalIssue"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#SupervisedStudentPublications"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#EncyclopediaEntry"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#MagazineArticle"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#DictionaryEntry"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ResearchTool"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#OnlineResource"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Test"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ConferenceAbstract"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ConferencePoster"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#MusicalComposition"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#MusicalPerformance"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Radio/TVProgram"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Script"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ShortFiction"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Theatric"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#VideoRecording"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#VisualArtwork"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#SoundDesign"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#SetDesign"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#LightDesign"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Choreography"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Curatorial/MuseumExhibitions"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#IntellectualProperty"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#License"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Disclosure"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#RegisteredCopyright"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Trademark"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#StandardandPolicy"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#TechnicalStandard"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#ResearchTechniques"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Invention"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/OutputTypes#Litigation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Conference">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>909ea9bd-e460-497e-8950-9ad306675ae9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An activity that brings together people to discuss topics around an agreed theme.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project, CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Book">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2b2f6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Book</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A book is a collection of leaves of paper, parchment, vellum, cloth, or other material (written, printed, or blank) fastened together along one edge, with or without a protective case or cover.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_B.cfm#book</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#BookReview">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2b2f7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Book Review</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A book review is an evaluative account of a recent book, usually written and signed by a qualified person, for publication in a current newspaper, magazine, or journal.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_R.cfm#review</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#BookChapterAbstract">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2b2f8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Book Chapter Abstract</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A book chapter abstract is a brief, objective representation of the essential content of a book chapter, presenting the main points in the same order as the original but having no independent literary value.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/index.cfm#abstract</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#BookChapterReview">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2b2f9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Book Chapter Review</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A book chapter review is an evaluative account of a recent book chapter, usually written and signed by a qualified person, for publication in a current newspaper, magazine, or journal.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_R.cfm#review</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Inbook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Inbook</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An inbook is a part of a book, usually untitled. May be a chapter (or section or whatever) and/or a range of pages.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/BibTeX#Entry_Types</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Anthology">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Anthology</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An anthology is a collection of extracts or complete works by various authors, selected by an editor for publication in a single volume or multivolume set. Anthologies are often limited to a specific literary form or genre (short stories, poetry, plays) or to a national literature, theme, time period, or category of author.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_A.cfm#anthology</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Monograph">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Monograph</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A monograph is a relatively short book or treatise on a single subject, complete in one physical piece, usually written by a specialist in the field. Monographic treatment is detailed and scholarly but not extensive in scope.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_M.cfm#monograph</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Referencebook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Referencebook</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A referencebook is a book designed to be consulted when authoritative information is needed, rather than read cover to cover. Reference books often consist of a series of signed or unsigned "entries" listed alphabetically under headwords or headings, or in some other arrangement (classified, numeric, etc.).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_r.cfm#referencebook</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Textbook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Textbook</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A textbook is an edition of a book specifically intended for the use of students who are enrolled in a course of study or preparing for an examination on a subject or in an academic discipline, as distinct from the trade edition of the same title. Also refers to the standard work used for a specific course of study, whether published in special edition or not.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_T.cfm#textbook</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Encyclopedia">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Encyclopedia</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An enzyclopedia is a book or numbered set of books containing authoritative summary information about a variety of topics in the form of short essays, usually arranged alphabetically by headword or classified in some manner. An entry may be signed or unsigned, with or without illustration or a list of references for further reading. Headwords and text are usually revised periodically for publication in a new edition.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_E.cfm#encyclopedia</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Manual">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Manual</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A manual refers to a book or pamphlet containing practical instructions, rules, or steps for performing a task or operation, assembling a manufactured object, or using a system or piece of equipment. Used synonymously with handbook (ODLIS Dictionary). A manual is a book that tells you how to do or operate something, especially one that comes with a machine (Grey Literature Typology.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_M.cfm#manual (ODLIS Dicationary); http://purl.org/ntk/gltype#manual (Grey Literature Typology)</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Otherbook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Otherbook</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Uncertain of definition</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">To books not specified other places?</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Journal">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Journal</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A journal is a periodical devoted to disseminating original research and commentary on current developments in a specific discipline, subdiscipline, or field of study (example: Journal of Clinical Epidemiology), usually published in quarterly, bimonthly, or monthly issues sold by subscription (click here to see an example). Journal articles are usually written by the person (or persons) who conducted the research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_J.cfm#journal</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#JournalArticle">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9e9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Journal Article</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A journal article is a self-contained nonfiction prose composition on a fairly narrow topic or subject, written by one or more authors and published under a separate title in a collection or periodical containing other works of the same form.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; HEFCE; CASRAI</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_A.cfm#article</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#JournalArticleAbstract">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9ea-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Journal Article Abstract</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A journal article abstract is a brief, objective representation of the essential content of an article, presenting the main points in the same order as the original but having no independent literary value.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/index.cfm#abstract</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#JournalArticleReview">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9eb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Journal Article Review</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A journal article review is an evaluative account of a recent of a newly published literary or scholarly work, usually written and signed by a qualified person, for publication in a current newspaper, magazine, or journal.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_R.cfm#review</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ConferenceProceedings">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9ec-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference Proceedings</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A conference proceeding is a collection of articles, published abstracs or posters gathered from a conference. Can have several editors.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pure4 Working group - DK</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ConferenceProceedingsArticle">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9ed-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference Proceedings Article</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A conference proceedings article is an article that has been presented at a conference. Articles has been collected and published in a proceeding.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pure4 Working group - DK</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Letter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9ee-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Letter</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A letter (also known as "communication") is a brief description of important new research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pure4 Working group - DK</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#LettertoEditor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9ef-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Letter to Editor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A letter, usually printed at the discretion of the publisher on the editorial page of a newspaper or magazine, in which a reader expresses his or her views on the subject of a previously published article or editorial, or on the editorial policy of the publication in general, sometimes followed by a brief response from the editor(s).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_l.cfm#lettereditor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#PhDThesis">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">PhD Thesis</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A PhD Thesis, is a Dissertation/Thesis that leads to the acquirement of a Ph.D. Degree.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pure4 Working group - DK</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#DoctoralThesis">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f1-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Doctoral Thesis</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A Doctoral Thesis is a Dissertation/Thesis that leads to the acquirement of a doctoral degree.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pure4 Working group - DK</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Report">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f2-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Report</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A report is a separately published record of research findings, research still in progress, or other technical findings, usually bearing a report number and sometimes a grant number assigned by the funding agency.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; Grey Literature Typology; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_R.cfm#report</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ShortCommunication">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Short Communication</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A short communication is a concise, but independent report representing a significant contribution to a subject.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ejbiotechnology.info/iaformato/short_communications.html</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Poster">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f4-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Poster</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A poster is a visual presentation of an academic subject presented at a conference.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Pure4 Working group - DK</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Presentation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Presentation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Uncertain of definition</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Presentation as in a speech? Paper presentation at a conference?</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Newsclipping">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f6-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Newsclipping</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A newsclipping is an article published in a newspaper, newsmagazine, or online news service, reporting the details of a current event or the latest information on a topic of general interest. News stories are usually short and often unattributed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_N.cfm#newsstory</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Commentary">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f7-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Commentary</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A commentary is a written explanation or criticism or illustration that is added to a book or other textual material.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Commentary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Annotation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>eda2d9f8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Annotation</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Transliteration">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>640b32f5-da23-47e4-961d-46d106cc06b9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Transliteration</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Translation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>f04aabeb-ee05-46b6-a7e8-1dc35bfd3c5d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Translation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Translations of books and articles that identify modifications to the original edition, such as a new or revised preface.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/translations</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#AuthoredBook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>2522c045-5090-4da2-824c-583e039e23b3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Authored Book</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Books written by a single author or collaboratively based on research or scholarly findings generally derived from peer reviewed funding.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/books</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#EditedBook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>f5e38c52-d56a-4878-879c-31526788b19d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Edited Book</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Books edited by a single author or collaboratively for the dissemination of research or scholarly findings that generally result from peer reviewed funding.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/edited-books</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ChapterinBook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>b7ddff91-81b9-42b1-8228-190329ea6557</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Chapter in Book</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Texts written by a single author or collaboratively based on research or scholarly findings and expertise in a field.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/book-chapters</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ScholarlyEdition">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>af3f2342-4724-4d04-8246-cc30f50a4f6d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Scholarly Edition</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A scholarly edition of a text is an edition that is reliable and useful for scholarly purposes. In order to fulfill such purposes, a scholarly edition must live up to high standards.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.iva.dk/bh/core%20concepts%20in%20lis/articles%20a-z/scholarly_edition.htm</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ConferenceContribution">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>43afa201-2979-42b0-b283-ed609058d90a</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference Contribution</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#WorkingPaper">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>3acbc6f9-8b04-4117-8222-f39c84c7b6c6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Working Paper</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Preliminary versions of articles that have not undergone review but that may be shared for comment.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/working-papers</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Artefact">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>93a40595-c066-4cb3-99a1-68f451e3a7cc</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Artefact</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Devicesandproducts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>2a10d453-7128-45dc-b5b0-040c0d06c7d7</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Devices and products</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Performance">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>2e0a25cd-88b5-4018-8de2-c12b3a702cfe</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Performance</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Collection of information records that, in combination, represent a full and up-to-date history of artistic or performance outputs resulting from, or related to, the person's research or scholarly activities. Works may be produced alone or collaboratively as a creative practice that lead to production and dissemination.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Exhibition">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>71e46c84-243c-410f-9f61-63ec75323c8b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Exhibition</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Showings of works of art under the direction of a curator, an artist or as a graduation exhibition.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/artistic-exhibitions</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Patent/publishedpatentapplication">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>274e99d8-1e36-4b3e-a998-2a3384e79f64</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Patent / published patent application</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Composition">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>6a49719d-1226-454b-bff5-04b6fd3f141c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Composition</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Design">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>ab0efef8-6ef2-4509-ae10-8ccce30075d9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Design</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Researchreportforexternalbody.">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>032f0d65-2461-492d-b718-2788ef5db869</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research report for external body.</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ConfidentialReport(forexternalbody).">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>ca47658a-322d-4010-94e6-81401dc5b565</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Confidential Report (for external body).</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Software">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>5b90f961-6489-4500-bb6a-5b60ead25a2d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Software</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Software is a generic term for computer programs and their associated documentation, as opposed to data used as input and generated as output.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary; Grey Literature Type</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://purl.org/ntk/gltype#software</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Websitecontent">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>898beff1-5f9d-4b8f-b9d8-660a783fae9a</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Website content</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Stand-alone locations on the web where multiple types of information on a specific theme are available. May include interactive features for contributions from readers.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary; Grey Literature Type</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/search/Website</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Digitalorvisualmedia">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>3c610d3c-b62a-4889-811b-dc9dbe40b847</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Digital or visual media</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Researchdatasetsanddatabases">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>b8da9b81-7cd8-4b33-88c5-28b41bbc49c9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research data sets and databases</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A series of structured observations, measurements or facts identified from the research which can be stored in a database medium.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/data-sets</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Other">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>7eb3f358-bfc1-45d4-9ec6-b16d99f0ded6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Other</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">HEFCE; RMAS project; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#JournalIssue">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>a85940d9-ad65-4a8d-ae54-23dda97c406e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Journal Issue</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Periodical publications aimed at fostering intellectual debate and inquiry. Special journal issues are produced by editors with an established record of scholarship in the field and able to provide the direction of the theme. Journal issues bear a unique number of reference for publication.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/journal-issues</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#SupervisedStudentPublications">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>b135c301-61d0-4d05-be98-e959f5c221dc</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Supervised Student Publications</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Articles on research findings published jointly with or supervised by the thesis advisor. The findings relate to research undertaken by the student or the supervisor’s program of research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/supervised-student-publications</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#EncyclopediaEntry">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>3f8f2c15-fbea-4b38-b517-3901378a9f1b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Encyclopedia Entry</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Authored entries in a reference work or a compendium focusing on a particular domain or on all branches of knowledge.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/encyclopedia-entries</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#MagazineArticle">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>d4753dda-e7a0-4837-ae7d-648a8d85b62c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Magazine Article</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Articles in thematic publications published at fixed intervals.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/magazine-articles</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#DictionaryEntry">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>71361e1a-03f1-4577-b91b-01cb87a2c280</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Dictionary Entry</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Entries of new words, new meanings of existing words, changes in spelling and hyphenation over a longer period of time, and grammatical changes.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/dictionary-entries</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ResearchTool">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>a79aca4a-3a43-4809-92a6-9ce690dd7f70</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Tool</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Series of observations, measurements or facts identified from the research. They include bibliographies, indices and catalogues of research collections; concordances and dictionaries; materials that facilitate access to archival holdings or collections such as repository guides, inventories of a group of manuscripts or of a body of archives, inventories or documentary materials, thematic guides to archival materials, records surveys and special indices; scholarly editions; and data series.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/research-tools</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#OnlineResource">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>db7bca87-379e-4854-a0d6-f9567226b1a6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Online Resource</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Information accessible only on the web via traditional technical methods (ie hyperlinks).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/online-resources</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Test">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>6915f869-e12e-42e8-b1b7-13bbea303d64</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Test</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Assessments that include tests designed for general university selection, selection into specific courses or other evaluation purposes.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/tests</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ConferenceAbstract">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>154e80ab-e825-4f7c-9430-bdf7ee971425</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference Abstract</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Texts of a specified length that states the issue to be discussed in a proposed conference paper. It serves as the basis for the acceptance of the paper at a conference. The abstract is published along with the paper.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/conferences/conference-abstracts</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ConferencePoster">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>93aa5afc-19e5-4995-99b5-47ee8c80b3fc</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Conference Poster</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Posters displayed in a conference setting and conveying research highlights in an efficient manner by compelling graphics. They may be peer-reviewed prior to acceptance and be published in the proceedings.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/conferences/conference-posters</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#MusicalComposition">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>d7e9d33a-20d4-447c-bd3f-6774afa23f4e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Musical Composition</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Original musical scores available in a format for dissemination.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/musical-compositions</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#MusicalPerformance">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>849fcbfa-f863-4e80-b7b9-811ccc1fb9c1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Musical Performance</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Original musical scores available in a format for dissemination.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/musical-performances</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Radio/TVProgram">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>ca4665dc-d9da-49c3-950d-f95699e28b10</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Radio/TV Program</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Programming produced for and broadcast on radio or TV.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/radiotv-programs</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Script">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>488c227d-ade1-45c5-bf13-77cec1e5033c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Script</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Written versions of a play, film, broadcast or other dramatic composition used in preparing for a performance and annotated with instructions for the performance.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/scripts</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ShortFiction">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>68bade0c-2ac6-4dd9-834e-dec1583a607f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Short Fiction</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Original literary texts (prose or poetry).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/short-fiction</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Theatric">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>c8b9bf7b-bb0c-493b-82aa-db9a5834f61e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Theatric</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Creation, production, dissemination of plays by professional theatre artists and organizations. The artifacts, such costumes, props, sets and scripts, may be the object of a public exhibit.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/theatric</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#VideoRecording">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>b4a6438e-4bcb-4d8b-9363-4f6488861249</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Video Recording</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Works such as film, video, or new media developed as a result of an artistic practice. May serve for commercial purposes.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/video-recordings</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#VisualArtwork">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>2dedf523-a6eb-4bfc-87e0-bc046e20f551</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Visual Artwork</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Works such as film, video, or new media developed as a result of an artistic practice. May serve for commercial purposes.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/visual-artworks</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#SoundDesign">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>5d46488d-2952-4c31-bcca-84cd3f13fe7e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Sound Design</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Art and process of manipulating audio elements to achieve a desired effect. It is employed in a variety of disciplines including film, theatre, music recording, and live music performance. It involves the manipulation of previously composed audio or the creative composition of new audio.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/sound-design</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#SetDesign">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>af08e1af-3d31-4b58-8ef1-8d5fc714a743</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Set Design</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Creations of theatrical, as well as film or television scenery (also known as stage design, scenic design or production design).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/set-design</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#LightDesign">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>41555114-5fdb-4ee9-b5e7-b3acb574310d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Light Design</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Works done within theatre or in relation to an art installation to design a production.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/light-design</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Choreography">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>77c9c66f-9e65-4876-8e82-34ac7c50582d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Choreography</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Dance compositions created for production and dissemination.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/choreography</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Curatorial/MuseumExhibitions">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>8b5e666b-6121-4b4d-b446-9ed6ad7ed35c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Curatorial/Museum Exhibitions</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Collection of information records that, in combination, represent a full and up-to-date history of the intellectual property owned by the person and resulting from, or related to, the person's research activities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/conferences</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#IntellectualProperty">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>64b9ce43-e5ed-4df2-86d5-01bc46939fd5</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Intellectual Property</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Collection of information records that, in combination, represent a full and up-to-date history of the intellectual property owned by the person and resulting from, or related to, the person's research activities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#License">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>2d8d91dc-00ef-4982-a6d2-0700b34b47fd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">License</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Signed agreements to exploit a piece of IP such as a process, product, data, or software.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/licenses</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Disclosure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>170136af-8bec-4b17-af16-c738633a3b96</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Disclosure</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Publications that establish inventions as prior art thereby preventing others from patenting the same invention or concept.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/disclosures</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#RegisteredCopyright">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>0f38dfac-b08c-4ed9-b627-df8f95d74bd5</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Registered Copyright</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Registered ownership of rights under a system of laws for promoting both the creation of and access to artistic, literary, musical, dramatic and other creative works.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/registered-copyrights</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Trademark">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>723f6119-ffac-4f4c-99d2-9c34eb644115</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Trademark</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Marks such as a name, word, phrase, logo, symbol, design, image of a product or service that indicates the source and provides the right to control the use of the identifier.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/trademarks</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#StandardandPolicy">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>6b7fdebc-f169-4a7a-89b4-539ff69c5dcd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Standard and Policy</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The development of a rule or principle that is used as a basis for judgement.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/standards-and-policies</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#TechnicalStandard">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>c03694e5-f58b-4a37-83ff-5f8285c67f66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Technical Standard</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Technical Standards (industrial or otherwise) that have originated from the research projects in which new protocols, methods or materials may be developed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/technical-standards</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#ResearchTechniques">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>b8b97010-577d-4ba2-9195-0b6cba3f0866</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Techniques</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A practical methods or skills applied to particular tasks identified as part of the research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/research-techniques</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Invention">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>76cf4c24-7f15-41b9-995f-889cec876b30</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Invention</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Practical and original outputs arising from research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/inventions</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/OutputTypes#Litigation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/OutputTypes"/>
+<dc:identifier>88478041-0fa4-4396-9246-6985ec0e9e6e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Litigation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The act or process of contesting at law.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/litigation</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PeerReviews.rdf
+++ b/vocab/rdf/PeerReviews.rdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PeerReviews">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>4bdfc4ac-7c74-456d-9d3b-b1e4267b90a9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Peer Reviews</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Whether or not the output is known to be peer-reviewed.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PeerReviews#Yes"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PeerReviews#No"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PeerReviews#Unknown"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PeerReviews#Yes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PeerReviews"/>
+<dc:identifier>df943548-c67e-4c96-8c4f-1c0aa144b1c0</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Yes</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Where the output has been subject to assessment and critique by independent experts.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PeerReviews#No">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PeerReviews"/>
+<dc:identifier>0c7c83d0-5513-4eaa-b5cf-d01374c3d2eb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">No</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Where the output has not been subject to assessment and critique by independent experts.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PeerReviews#Unknown">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PeerReviews"/>
+<dc:identifier>22b56ddc-87e8-4023-ab56-e661dcb8ffd3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Unknown</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Where it is unknown whether the output has been subject to assessment and critique by independent experts.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonContactDetails.rdf
+++ b/vocab/rdf/PersonContactDetails.rdf
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>05cc5ff9-bc58-4743-ab59-46e5013e0039</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Contact Details</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person's electronic and postal contact coordinates. This scheme contains CERIF vocabulary terms applicable in the cfPerson_ElectroniAddress or cfPerson_PostAddress link entity, being thus person contact details.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#Fax"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#Email"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#ProfessionalEmail"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#PersonalEmail"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#Skype"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#Twitter"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#Facebook"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#LinkedIn"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#Phone"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#PublicAccess"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#CorporateAccess"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails#PersonProfessionalPostalAddress"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#Fax">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>9931ac41-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Fax</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#Email">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>9931ac42-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Email</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#ProfessionalEmail">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>35d43364-2160-4b6c-a487-5019458321e8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Professional Email</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#PersonalEmail">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>4523402a-0bae-4716-a5d7-77411b74d5f6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Personal Email</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#Skype">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>20476135-bc75-40b4-b5f0-f05543e919c6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Skype</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#Twitter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>95bff29c-338f-4790-80ac-c39ec3bc72f4</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Twitter</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#Facebook">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>beb680a9-4504-417f-b444-65ff289c5952</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Facebook</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#LinkedIn">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>48ed3997-8f3b-41bd-94c5-ba37df71c263</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">LinkedIn</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#Phone">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>9931ac44-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Phone</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#PublicAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>9931ac45-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Public Access</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#CorporateAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>9931ac46-3864-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Corporate Access</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonContactDetails#PersonProfessionalPostalAddress">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonContactDetails"/>
+<dc:identifier>6947fabb-a277-4f8f-b148-c6b41a936c57</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Professional Postal Address</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The work address of a person to which physical correspondance can be delivered.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonDegreeLevelsOfStudy.rdf
+++ b/vocab/rdf/PersonDegreeLevelsOfStudy.rdf
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>a1a55095-45c2-456c-9869-add5d726c676</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Degree Levels of Study</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The level of degree a person is studying for.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy#Master"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy#Doctorate"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy#HigherDoctorate"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy#Master">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy"/>
+<dc:identifier>a32a9785-0d15-48ba-aca8-0be319578e5e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Master</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A degree above Bachelor level, that normally takes 1 to 2 years of effort.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy#Doctorate">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy"/>
+<dc:identifier>f7d5892b-8be3-42fa-8d4b-e18fe9bed062</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Doctorate</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A degree above Masters level, that normally takes 3 to 4 years of effort.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy#HigherDoctorate">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonDegreeLevelsofStudy"/>
+<dc:identifier>73451d3c-9afa-4484-8404-cd1518ef508b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Higher Doctorate</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A degree above doctorate level, that normally is associated with a life-time achievement.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonEmploymentTypes.rdf
+++ b/vocab/rdf/PersonEmploymentTypes.rdf
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>e9616dbd-0d38-4b7d-a6cd-3c4df1e95462</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Employment Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_OrganisationUnit link entity with respect to employment, being thus employment types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes#Administrator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes#Technician"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes#AcademicTeachingonly"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes#ResearchAssociate"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes#AcademicResearch"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes#Supporter"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes#Administrator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes"/>
+<dc:identifier>b9bd41f0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Administrator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, administrator is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Administrator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities (CERIF Task Group). An administrator directly employed by an organisation (RMAS Project).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An administrator directly employed on an activity or a person not directly involved in the activity but with information related to the activity (e.g. finance, computing, hr), where they are not a contact.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes#Technician">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes"/>
+<dc:identifier>8adcdf20-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Technician</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, technician is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Technician" identified by its cfClassificationIdentifier (a uuid) and reused inlink entities. (CERIF Task Group) A permanent Research staff. (RMAS project)</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A technician is someone known for high skill in some intellectual or artistic technique.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=technician</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes#AcademicTeachingonly">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes"/>
+<dc:identifier>7a642fac-777a-43b7-a0c1-90b88428e125</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Academic Teaching only</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A permanent teaching stuff.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes#ResearchAssociate">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes"/>
+<dc:identifier>df5ec85e-c645-449f-9473-41c9f9923cb7</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Associate</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research-only, non-teaching staff, not member of permanent staff.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes#AcademicResearch">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes"/>
+<dc:identifier>fd742fb8-fa7f-40b4-a015-c7deb93902f6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Academic Research</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A permanent research and teaching staff.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEmploymentTypes#Supporter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEmploymentTypes"/>
+<dc:identifier>eda28bc5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Supporter</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A supporter is someone who supports or champions something.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=supporter</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonEventInvolvements.rdf
+++ b/vocab/rdf/PersonEventInvolvements.rdf
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>b4de9a8f-3a4d-4233-9a9f-3b624e4ad74f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Event Involvements</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Event link entity being thus person event involvements.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Participant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Contributor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Performer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Choreographer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Interviewee"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Speaker"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#PanelParticipant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#ProgrammeCommitteeMember"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Reporter"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Rapporteur"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#PeerReviewer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements#Organiser"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Participant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>ddc3dd10-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Participant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, participant is a role e.g. in the person-project relationship; that is, the classification term (cfTerm) "Participant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A participant is someone who takes part in an activity</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=participant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Contributor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contributor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CIA project; RMAS Project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Performer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>ee155a46-9850-48aa-98c2-e70ecb0f5d3b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Performer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who performs at an event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Choreographer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>92e7478e-5a7c-4c72-a14e-a5770619251e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Choreographer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A Choreographer is a person who creates dances. This person decides what the steps will be, and then a dancer performs the steps. Some people have jobs as choreographers. Some people do it just for fun. This person gets to work with a lot of different dancers, including celebrities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://simple.wikipedia.org/wiki/Choreographer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Interviewee">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>2b3ba8f1-5620-42c9-8549-7d34ed37f968</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Interviewee</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person that is interviewed at an event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Speaker">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>d1ee35f1-c4c6-4651-a760-06a3828a61c1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Speaker</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person that speaks at an event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#PanelParticipant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>1ca8d2bc-9424-4df4-ae4b-8ce65239c770</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Panel Participant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Member of a discussion panel at an event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#ProgrammeCommitteeMember">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>1869a08e-3257-457b-9278-ed32bd915ee8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Programme Committee Member</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Member of the group of people who organise and manage the content of the event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Reporter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>dc42714f-56de-441f-9161-a51d8edbcb8d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reporter</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person to report about the event (e.g. journalist) to the general public.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Rapporteur">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>86bacee1-49d8-429d-97aa-5f4918d3ae88</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Rapporteur</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person to report about the 'technical' content of an event (also implies part of event, e.g. session) for the benefit of people attending or wished to attend (i.e. subject community).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#PeerReviewer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>d9a6b8e4-38af-4492-b178-3326173ec657</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Peer Reviewer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subject expert reviewing content submissions to inform the process for selection of content at the event. This may also involve feedback to contributors to improve content.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonEventInvolvements#Organiser">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonEventInvolvements"/>
+<dc:identifier>b4ba809e-60d7-411c-af62-792100c45341</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Organiser</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The person responsible for organizing the event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonFundingRoles.rdf
+++ b/vocab/rdf/PersonFundingRoles.rdf
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonFundingRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af934-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Funding Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Funding link entity, being thus person funding roles such as manager or contact, where funding subsumes funding programme, tender, call, and not the income as such, which would be a financial means and as such in CERIF be a measurement.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonFundingRoles#Manager"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonFundingRoles#Contact"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonFundingRoles#Applicant"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonFundingRoles#Manager">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonFundingRoles"/>
+<dc:identifier>79a2e340-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Manager</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A manager is someone who controls resources and expenditures.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonFundingRoles#Contact">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonFundingRoles"/>
+<dc:identifier>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contact</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The person to be contacted in a particular circumstance (e.g. finance).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contact is a communicative interaction.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contact</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonFundingRoles#Applicant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonFundingRoles"/>
+<dc:identifier>33551370-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Applicant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An applicant is also called proposer.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonNames.rdf
+++ b/vocab/rdf/PersonNames.rdf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonNames">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>7375609d-cfa6-45ce-a803-75de69abe21f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Names</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable with the cfPersonName_Person link entity, being thus a vocabulary of person name variants.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonNames#PassportName"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonNames#ShortName"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonNames#Initials"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonNames#PresentedName"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonNames#PreviousFamilyName"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonNames#PassportName">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonNames"/>
+<dc:identifier>64f0eb00-462d-4737-8033-7efac82decf3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Passport Name</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The name of the person as printed in the passport</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonNames#ShortName">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonNames"/>
+<dc:identifier>bdcf213d-df3e-4af4-a2ea-69ca26e98cd4</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Short Name</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The name of the person in short.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonNames#Initials">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonNames"/>
+<dc:identifier>5f3df96e-eb12-46b1-8458-c85914e2fc4c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Initials</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The initials deduced from a person's name.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonNames#PresentedName">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonNames"/>
+<dc:identifier>55f90543-d631-42eb-8d47-d8d9266cbb26</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Presented Name</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The given and surname of the reference.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-activity-profile-v0.9-draft/1.1.0/funding-requests/references/presented-name</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonNames#PreviousFamilyName">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonNames"/>
+<dc:identifier>c54976a0-6793-4e62-b77d-7871ccb6ef0b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Previous Family Name</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The previous surname of the person if, for example, there has been a change due to marriage.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dictionary.casrai.org/research-personnel-profile/1.1.0/identification/person-info/previous-family-name</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonOrganisationRoles.rdf
+++ b/vocab/rdf/PersonOrganisationRoles.rdf
@@ -1,0 +1,596 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>994069a0-1cd6-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Organisation Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_OrganisationUnit link entity without further specification, being thus Person Organisation Roles.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Professor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Associate"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Affiliation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Subaffiliation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Head"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Employee"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Member"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Director"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#DeputyDirector"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Dean"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Principle"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#HeadofDepartment"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#GroupLeader"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Manager"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Spokesperson"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Fellow"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Reviewer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Contractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Subcontractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Engineer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Secretary"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Researcher"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#JuniorResearcher"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#SeniorResearcher"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Consultant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#JuniorConsultant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#SeniorConsultant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Lecturer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#JuniorLecturer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#SeniorLecturer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#GuestLecturer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#AssistantProfessor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#HonoraryProfessor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#VisitingProfessor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Doctor(med)"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#ResearchFellow"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Postdoc"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#PhDStudent"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#ResearchAssistant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Reader"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#TeachingFellow"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#TeachingAssistant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Casual"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Expert"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Contributor"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Professor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>3bb53320-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Professor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A professor is someone who is a member of the faculty at a college or university.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=professor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Associate">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>a27e5ca7-3d20-4272-9054-7db550e2a053</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Associate</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, associate is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Associate" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An associate is a person with subordinate membership in a society, institution, or commercial enterprise.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=associate</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Affiliation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>980965b0-1cd5-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Affiliation</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, affiliation is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Affiliation" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An affiliation is a formal connection,</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Subaffiliation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>081e85f0-1cd7-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subaffiliation</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, subaffiliation is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Subaffiliation" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A subaffiliation is a formal subconnection of an affiliation.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Head">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>6125f750-1cd7-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Head</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, head is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Head" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who is in charge</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=head</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Employee">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>c302c2f0-1cd7-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Employee</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, employee is a role e.g. in the person-organisation relationship; that is, the classification term (cfTerm) "Employee" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A worker who is hired to perform a job</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Employee</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Member">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>cb3e0010-1cd7-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Member</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the member role happens e.g. within the relationships person-organisation, person-project; organisation-organisation, that is, the classification term (cfTerm) "Member" identified by its cfClassificationIdentifier (a uuid), and reused with e.g. the cfPerson_OrganisationUnit; cfProject_Person; cfOrganisationUnit_OrganisationUnit relationships. A person can be a member of multiple organisations. An organization can be a member of another organization, or a state that belongs to a group of nations.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A member is anything that belongs to a set or class.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=member</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Director">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>68971130-1cd8-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Director</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, director is e.g. a role in the person-organisation relationship; that is, the classification term (cfTerm) "Director" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A director is someone who controls resources and expenditures</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=director</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#DeputyDirector">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>885eeb00-1cf6-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Deputy Director</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, deputy director is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Deputy Director" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A deputy director is a person appointed to represent or act on behalf of the director</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=deputy</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Dean">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>57f7a7d0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Dean</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, dean is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Dean" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A dean is an administrator in charge of a division of a university or college.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=dean</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Principle">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>612163a0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Principle</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, principle is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Principle" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A principle is a person who empowers another to act as his or her representative; The person having prime responsibility for an obligation as distinguished from one who acts as surety or as an endorser. (law)</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.yourdictionary.com/principal</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#HeadofDepartment">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>68cdce40-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Head of Department</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, head of department is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Head of Department" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A head of department is a person who is in charge of a specialized division of a large organization.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=department; http://wordnetweb.princeton.edu/perl/webwn?s=headhttp://wordnetweb.princeton.edu/perl/webwn?s=department; http://wordnetweb.princeton.edu/perl/webwn?s=head</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#GroupLeader">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>7210b760-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Group Leader</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, group leader is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Group Leader" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A group leader is a person who rules or guides or inspires others or any number of entities (members) considered as a unit.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=group; http://wordnetweb.princeton.edu/perl/webwn?s=leader</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Manager">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>79a2e340-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Manager</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A manager is someone who controls resources and expenditures.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Spokesperson">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>8418a710-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Spokesperson</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, spokesperson is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Spokesperson" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A spokesperson is an advocate who represents someone else's policy or purpose.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=spokesperson</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Fellow">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>94d55210-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Fellow</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, fellow is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Fellow" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A fellow is a member of a learned society.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=fellow</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Reviewer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reviewer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reviewer is someone who reads manuscripts and judges their suitability for publication.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Contractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>abf21190-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Subcontractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>b272a660-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subcontractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A subcontractor is someone who enters into a subcontract with the primary contractor.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=subcontractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Engineer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>057a7d50-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Engineer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit or cfProject_Person link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who uses scientific knowledge to solve practical problems.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=engineer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Secretary">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>c6e02460-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Secretary</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, secretary is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Secretary" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A secretary is a person who is head of an administrative department of government, an assistant who handles correspondence and clerical work for a boss or an organization</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=secretary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Researcher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>ebd55ab0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Researcher</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A researcher is a scientist who devotes himself to doing research (Wordnet). Permanent research, non-teaching staff (RMAS Project).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=researcher</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#JuniorResearcher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>f401a3b0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Junior Researcher</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, junior researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Junior Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A junior researcher is a scientist who devotes himself to doing research but younger; lower in rank; shorter in length of tenure or service</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Junior; http://wordnetweb.princeton.edu/perl/webwn?s=researcher</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#SeniorResearcher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>faf322c0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Senior Researcher</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, senior researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Senior Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A senior researcher is a scientist who devotes himself to doing research and is older; higher in rank; longer in length of tenure or service</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=senior; http://wordnetweb.princeton.edu/perl/webwn?s=researcher</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Consultant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>04c3f400-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Consultant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A consultant is an expert who gives advice.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=consultant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#JuniorConsultant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>0bb17b70-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Junior Consultant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, junior consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Junior Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A junior consultant is an expert who gives advice and that is younger; lower in rank; shorter in length of tenure or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=junior; http://wordnetweb.princeton.edu/perl/webwn?s=consultant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#SeniorConsultant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>13633d40-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Senior Consultant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, senior consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Senior Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A senior consultant is an expert who gives advice that is older; higher in rank; longer in length of tenure or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=consultant; http://wordnetweb.princeton.edu/perl/webwn?s=senior</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Lecturer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>1a3c5250-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Lecturer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A lecturer is someone who lectures professionally, a public lecturer at certain universities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=lecturer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#JuniorLecturer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>23b16f00-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Junior Lecturer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, junior lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Junior Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A junior lecturer is someone who lectures professionally, a public lecturer at certain universities and is younger; lower in rank; shorter in length of tenure or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=lecturer; http://wordnetweb.princeton.edu/perl/webwn?s=junior</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#SeniorLecturer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>2b20d0a0-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Senior Lecturer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, senior lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Senior Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A senior lecturer is someone who lectures professionally, a public lecturer at certain universities and is older; higher in rank; longer in length of tenure or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=senior; http://wordnetweb.princeton.edu/perl/webwn?s=lecturer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#GuestLecturer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>33661fe0-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Guest Lecturer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, guest lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Guest Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A guest lecturer is someone who lectures professionally, a public lecturer at certain universities and is a visitor to whom hospitality is extended.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=guest; http://wordnetweb.princeton.edu/perl/webwn?s=lecturer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#AssistantProfessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>45aec210-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Assistant Professor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, assistant professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Assistant Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An assistant professor is a university teacher lower in rank than an associate professor.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.thefreedictionary.com/assistant+professor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#HonoraryProfessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>4dfbb270-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Honorary Professor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, honorary professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Honorary Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An honorary professor is given an honor without the normal duties of a professor, someone who is a member of the faculty at a college or university.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=honorary; http://wordnetweb.princeton.edu/perl/webwn?s=professor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#VisitingProfessor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>55ddd310-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Visiting Professor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, visiting professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Visiting Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A visiting professor is in the activity of a professor making visits.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=visiting; http://wordnetweb.princeton.edu/perl/webwn?s=professor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Doctor(med)">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>5d1534c0-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Doctor (med)</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, doctor (med) is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Doctor (med)" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A doctor (med) is a licensed medical practitioner.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Doctor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#ResearchFellow">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>64af4fe0-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Fellow</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, research fellow is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Research Fellow" identified by its cfClassificationIdentifier (a uuid) and reused in in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The title of research fellow is used to denote a research position at a university or similar institution, usually for academic staff or faculty members. A research fellow may act either as an independent investigator or under the supervision of a principal investigator.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Research_fellow</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Postdoc">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>6c68b2d0-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Postdoc</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, postdoc is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Postdoc" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A PostDoc is a scholar or researcher who is involved in academic study beyond the level of a doctoral degree</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Postdoc</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#PhDStudent">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>727f6240-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">PhD Student</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, phd is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "PhD" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A Phd or doctor's degree; doctorate is usually based on at least 3 years graduate study and a dissertation; the highest earned academic degrees conferred by a university.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=PhD</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#ResearchAssistant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>7a510820-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Assistant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, research assistant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Research Assistant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A research assistant (in some institutions referred to as research officer) is a researcher employed, often on a temporary contract,[1] by a university or a research institute, for the purpose of assisting in academic research. Research assistants are not independent and not directly responsible for the outcome of the research and are responsible to a supervisor or principal investigator. Research assistants are often educated to degree level[2] and might be enrolled in a postgraduate degree programme. Although a research assistant is normally appointed at graduate level, so-called undergraduate research assistant are also sometimes appointed to support research. Similarly a postdoctoral research assistant who has recently been awarded a doctoral degree, may hold a temporary appointment as a research assistant, especially for position without any autonomy and research independence that requires a high degree of reliability.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Research_assistant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Reader">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>80cae630-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reader</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, reader is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Reader" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reader is a public lecturer at certain universities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=reader</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#TeachingFellow">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>91784ef0-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Teaching Fellow</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, teaching fellow is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Teaching Fellow" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A teaching fellow is a particular teaching role at some universities. In the USA a teaching fellow is an advanced graduate student who serves as the primary instructor for an undergraduate course. In the UK, teaching fellows are more commonly full members of academic staff who have the equivalent rank and pay as 'traditional' research-active academic staff.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Teaching_fellow</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#TeachingAssistant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>99c34380-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Teaching Assistant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, teaching assistant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "teaching assistant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A teaching assistant is an individual who assists a professor or teacher with instructional responsibilities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Teaching_assistant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Casual">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>a3bf6a80-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Casual</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, casual is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Casual" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A caual is a person without or seeming to be without plan or method.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=casual</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Expert">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>a9fc3f90-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Expert</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, expert is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Expert" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An expert is a person with special knowledge or ability who performs skillfully.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=expert</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOrganisationRoles#Contributor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOrganisationRoles"/>
+<dc:identifier>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contributor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CIA project; RMAS Project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonOutputContributions.rdf
+++ b/vocab/rdf/PersonOutputContributions.rdf
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>b7135ad0-1d00-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Output Contributions</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_ResultPublication link entity - being person output contribution.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Reviewer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Contributor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Performer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Choreographer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Applicant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Author"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Author(numbered)"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Author(percentage)"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Creator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Editor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Translator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Publisher"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Commissioner"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#GroupAuthors"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Subject"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Illustrator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#GuestEditor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Patentee"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Holder"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Designer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Artist"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Constructor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Composer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Programmer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Analyst"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Validator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions#Tester"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Reviewer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reviewer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reviewer is someone who reads manuscripts and judges their suitability for publication.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Contributor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contributor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CIA project; RMAS Project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Performer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>ee155a46-9850-48aa-98c2-e70ecb0f5d3b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Performer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who performs at an event.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Choreographer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>92e7478e-5a7c-4c72-a14e-a5770619251e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Choreographer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A Choreographer is a person who creates dances. This person decides what the steps will be, and then a dancer performs the steps. Some people have jobs as choreographers. Some people do it just for fun. This person gets to work with a lot of different dancers, including celebrities.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://simple.wikipedia.org/wiki/Choreographer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Applicant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>33551370-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Applicant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An applicant is also called proposer.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Author">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>49815870-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Author</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An author is the person or corporate entity responsible for producing a written work (essay, monograph, novel, play, poem, screenplay, short story, etc.) whose name is printed on the title page of a book or given elsewhere in or on a manuscript or other item and in whose name the work is copyrighted. A work may have two or more joint authors. In library cataloging, the term is used in its broadest sense to include editor, compiler, composer, creator, etc</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_e.cfm#author</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Author(numbered)">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>505eb340-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Author (numbered)</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF this role requires a cfFraction attribute to indicate the number of authorschip.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Author(percentage)">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>5a4c3440-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Author (percentage)</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF this role requires a cfFraction attribute to indicate the percentage of authorschip.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Creator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>60f2a090-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Creator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An entity primarily responsible for making the resource.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://dublincore.org/documents/dces/#creator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Editor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>708b3df0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Editor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who prepares for publication the work(s) of one or more other authors. An editor may be responsible for selecting material included in a collection or for preparing manuscript copy for the printer, including annotation of the text, verification of the accuracy of facts and bibliographic citations, polishing grammar and style, organizing front and back matter, etc. Periodicals and large reference works often have a general editor or editor-in-chief who supervises the work of an editorial staff.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_e.cfm#editor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Translator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>7ef398b1-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Translator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who renders speech or text from one language in another or from an older form of a language into a more modern form. Translations of a work often differ in fidelity to the original. Name of translator usually appears on the title page of a book, following the name of the author.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_t.cfm#translator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Publisher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>7ef398b2-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Publisher</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person or corporate entity that prepares and issues printed materials for public sale or distribution, normally on the basis of a legal contract in which the publisher is granted certain exclusive rights in exchange for assuming the financial risk of publication and agreeing to compensate the author, usually with a share of the profits.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_t.cfm#publisher</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Commissioner">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>7ef398b3-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Commissioner</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A government administrator, a member of a commission.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_t.cfm#commissioner</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#GroupAuthors">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>7ef398b4-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Group Authors</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Any number of authors considered as a unit.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Subject">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>7ef3bfc0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subject</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Any one of the topics or themes of a work, stated explicitly in the text or title or implicit in its message. In library cataloging, a book or other item is assigned one or more subject headings as access points, to assist users in locating its content by subject. In abstracting and indexing services, the headings assigned to represent the content of a document are called descriptors</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_s.cfm#subject</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Illustrator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>7e2e67e4-e085-406c-a9c3-2a3df2bfc376</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Illustrator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An artist who makes illustrations (for books or magazines or advertisements etc.).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=illustrator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#GuestEditor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>5282d01e-f788-42b5-9ccb-eb8cc0626d4b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Guest Editor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">As guest-editing can be a demanding and time-consuming project, most volumes are organized by a team of people rather than an individual. Two or three editors tends to work best.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Patentee">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>5b6b6bf2-c949-4c9e-ab4c-ffaa196b8355</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Patentee</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The inventor to whom a patent is issued.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=patentee</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Holder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>74e43aa3-233d-4a59-b9bf-0bd733c9e9f8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Holder</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Designer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>d03c6c91-1c65-442e-82e2-a2194b0e1907</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Designer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Someone who creates plans to be used in making something (such as buildings).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=designer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Artist">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>97fb8809-d23d-4826-b99d-6b5d666e1f33</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Artist</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An artist is a person engaged in one or more of any of a broad spectrum of activities related to creating art, practicing the arts and/or demonstrating an art. The common usage in both everyday speech and academic discourse is a practitioner in the visual arts only.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Artist</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Constructor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>62226b46-2ea3-46f4-b924-80ea42055587</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Constructor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Someone who contracts for and supervises construction (as of a building)).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=constructor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Composer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>b14b3a56-64c0-4d59-ad64-7d7af09ea529</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Composer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Someone who composes music as a profession.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=composer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Programmer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>aa82a7f8-8713-43f2-b7b4-e4d2196b1a3c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Programmer</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who designs and writes and tests computer programs.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=programmer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Analyst">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>cd5bb616-a187-4600-b2d2-0eac76a3be63</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Analyst</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Someone who is skilled at analyzing data.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=analyst</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Validator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>6d95cff9-0ae3-4dc2-8566-5a31fd8e75f9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Validator</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonOutputContributions#Tester">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonOutputContributions"/>
+<dc:identifier>f94f7ec1-263a-4898-8286-4e7ba44af0d1</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Tester</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Someone who administers a test to determine your qualifications.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=tester</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonProfessionalRelationships.rdf
+++ b/vocab/rdf/PersonProfessionalRelationships.rdf
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6b2b7d24-3491-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Professional Relationships</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Person link entity, being thus an interpersonal structure.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Co-Investigator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Mentor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Supervisor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Co-Supervisor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#ExternalSupervisor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Advisor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Colleague"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Co-Researcher"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Co-Investigator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>bc34dc30-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Co-Investigator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, co-investigator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Co-Investigator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A co-investitagor is also called co-promoter (quite often from different organizations). A co-investigator, fellow worker, workfellow (an associate that one works with).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Mentor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>6b2b7d22-3491-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Mentor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A mentor is a wise and trusted guid and advisor.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group, RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=mentor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Supervisor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>6b2b7d23-3491-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Supervisor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person wich the official task of overseeing the work of a person or group.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=supervisor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Co-Supervisor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>ab0ed712-6e50-46a5-8fa2-5d9b87c27e6d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Co-Supervisor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Is an additional member of the supervisory team, that guides a research student through their programme of studies. Often he/she has complementory expertise to the supervisor.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#ExternalSupervisor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>3ccd035b-bc79-477e-aa6c-0bd3606f85c8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">External Supervisor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A co-supervisor that is external to the host institution of the research student.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Advisor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>81d0d105-216f-42f0-8c96-a87ba2adfa41</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Advisor</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person that has an adhoc, informal input into the work of the supervisory team.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Colleague">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>1d689234-c537-4bba-b59a-2d85e1efcd1d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Colleague</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A co-worker, fellow worker, workfellow (an associate that one works with.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=colleague</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProfessionalRelationships#Co-Researcher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProfessionalRelationships"/>
+<dc:identifier>78883ba6-a5ac-45d4-a2e2-20b3f7f43a63</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Co-Researcher</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonProjectEngagements.rdf
+++ b/vocab/rdf/PersonProjectEngagements.rdf
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>94fefd50-1d00-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Project Engagements</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfProject_Person link entity with respect to person project engagement.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Member"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Manager"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Spokesperson"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Reviewer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Contractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Subcontractor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Engineer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Administrator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Technician"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Researcher"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Consultant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#PhDStudent"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Investigator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#PrincipalInvestigator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Co-Investigator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Collaborator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#HighlyQualifiedPersonel"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#ResearchStudent"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Supporter"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#ProjectOfficer"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Coordinator"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Participant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Contributor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Contact"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Applicant"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements#Subject"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Member">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>cb3e0010-1cd7-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Member</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the member role happens e.g. within the relationships person-organisation, person-project; organisation-organisation, that is, the classification term (cfTerm) "Member" identified by its cfClassificationIdentifier (a uuid), and reused with e.g. the cfPerson_OrganisationUnit; cfProject_Person; cfOrganisationUnit_OrganisationUnit relationships. A person can be a member of multiple organisations. An organization can be a member of another organization, or a state that belongs to a group of nations.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A member is anything that belongs to a set or class.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=member</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Manager">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>79a2e340-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Manager</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A manager is someone who controls resources and expenditures.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Spokesperson">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>8418a710-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Spokesperson</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, spokesperson is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Spokesperson" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A spokesperson is an advocate who represents someone else's policy or purpose.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=spokesperson</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Reviewer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reviewer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A reviewer is someone who reads manuscripts and judges their suitability for publication.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Contractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>abf21190-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Subcontractor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>b272a660-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subcontractor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A subcontractor is someone who enters into a subcontract with the primary contractor.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=subcontractor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Engineer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>057a7d50-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Engineer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit or cfProject_Person link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person who uses scientific knowledge to solve practical problems.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=engineer</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Administrator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>b9bd41f0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Administrator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, administrator is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Administrator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities (CERIF Task Group). An administrator directly employed by an organisation (RMAS Project).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An administrator directly employed on an activity or a person not directly involved in the activity but with information related to the activity (e.g. finance, computing, hr), where they are not a contact.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Technician">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>8adcdf20-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Technician</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, technician is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Technician" identified by its cfClassificationIdentifier (a uuid) and reused inlink entities. (CERIF Task Group) A permanent Research staff. (RMAS project)</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A technician is someone known for high skill in some intellectual or artistic technique.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=technician</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Researcher">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>ebd55ab0-1cfc-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Researcher</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A researcher is a scientist who devotes himself to doing research (Wordnet). Permanent research, non-teaching staff (RMAS Project).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=researcher</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Consultant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>04c3f400-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Consultant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A consultant is an expert who gives advice.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=consultant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#PhDStudent">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>727f6240-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">PhD Student</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, phd is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "PhD" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A Phd or doctor's degree; doctorate is usually based on at least 3 years graduate study and a dissertation; the highest earned academic degrees conferred by a university.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=PhD</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Investigator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>e7036eeb-aca5-48d6-9ba1-c4c1d8fd96eb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Investigator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Someone who investigates</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=investigator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#PrincipalInvestigator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>b0e11470-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Principal Investigator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, principal investigator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Principal Investigator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A principal investigator (PI) is the lead scientist or engineer for a particular well-defined science (or other research) project, such as a laboratory study or clinical trial. It is often used as a synonym for "head of the laboratory," not just for a particular study. In the context of USA federal funding from agencies such as the NIH or the NSF, the PI is the person who takes direct responsibility for completion of a funded project, directing the research and reporting directly to the funding agency.[1] For small projects (which might involve 1-5 people) the PI is typically the person who conceived of the investigation, but for larger projects the PI may be selected by a team to obtain the best strategic advantage for the project. In the context of a clinical trial a PI may be an academic working with grants from NIH or other funding agencies, or may be effectively a contractor for a pharmaceutical company working on testing the safety and efficacy of new medicines.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Principal_investigator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Co-Investigator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>bc34dc30-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Co-Investigator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, co-investigator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Co-Investigator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A co-investitagor is also called co-promoter (quite often from different organizations). A co-investigator, fellow worker, workfellow (an associate that one works with).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Collaborator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>541b4224-a784-49b7-a341-8275ce874ada</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Collaborator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person that is formally a member of the project consortium.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#HighlyQualifiedPersonel">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>65c14308-310c-4198-be0b-43a6a1697038</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Highly Qualified Personel</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A person whose role on an activity is research and development (e.g. Researcher, PostDoc; PostGrad Research Assistant).</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#ResearchStudent">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>2a9173a6-3725-43f3-aed1-1d754b30f57d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Student</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Somebody undertaking a degree by research.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Supporter">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>eda28bc5-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Supporter</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A supporter is someone who supports or champions something.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=supporter</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#ProjectOfficer">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>254cb300-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project Officer</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, project officer is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Project Officer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A project officer is a person within the funding organsiation responsible for the project.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Coordinator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>c31d3380-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Coordinator</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, coordinator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Coordinator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A coordinator is someone whose task is to see that work goes harmoniously.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=coordinator</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Participant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>ddc3dd10-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Participant</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, participant is a role e.g. in the person-project relationship; that is, the classification term (cfTerm) "Participant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A participant is someone who takes part in an activity</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=participant</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Contributor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contributor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CIA project; RMAS Project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Contact">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contact</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The person to be contacted in a particular circumstance (e.g. finance).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contact is a communicative interaction.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contact</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Applicant">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>33551370-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Applicant</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An applicant is also called proposer.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonProjectEngagements#Subject">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonProjectEngagements"/>
+<dc:identifier>7ef3bfc0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Subject</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Any one of the topics or themes of a work, stated explicitly in the text or title or implicit in its message. In library cataloging, a book or other item is assigned one or more subject headings as access points, to assist users in locating its content by subject. In abstracting and indexing services, the headings assigned to represent the content of a document are called descriptors</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://lu.com/odlis/odlis_s.cfm#subject</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonResearchInfrastructureRoles.rdf
+++ b/vocab/rdf/PersonResearchInfrastructureRoles.rdf
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>3fe69a55-34c3-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Research Infrastructure Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Equipment; cfPerson_Service, cfPerson_Facility link entities, being thus person infrastructure roles.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#Contact"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#Responsible"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#User"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#Staff"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#Contact">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles"/>
+<dc:identifier>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Contact</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The person to be contacted in a particular circumstance (e.g. finance).</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A contact is a communicative interaction.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=contact</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#Responsible">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles"/>
+<dc:identifier>eda2b2e3-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Responsible</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A responsible is the agent or cause; worthy of or requiring responsibility or trust; or held accountable.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=responsible;</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#User">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles"/>
+<dc:identifier>eda2da00-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">User</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles#Staff">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonResearchInfrastructureRoles"/>
+<dc:identifier>eda2da01-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Staff</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PersonTitles.rdf
+++ b/vocab/rdf/PersonTitles.rdf
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+	<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>b93fc7ba-90be-4825-a1fd-363bd2fd1432</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Person Titles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The personal honorific titles (may be more than one).</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Dr"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Miss"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Mr"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Mrs"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Ms"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Professor"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Reverend"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Sir"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Associate"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Dame"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Emeritus"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PersonTitles#Colonel"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Dr">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>8f558c1a-be74-4d3c-8f19-fdd645b61c0a</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Dr</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Miss">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>bd2600ce-3bcf-4193-be07-8beaa76b91dd</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Miss</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Mr">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>3bd6c3dd-7132-465e-923b-d7ceeeda93d6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Mr</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Mrs">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>2e7190cc-51b9-49d3-a11d-bc739e3dabfb</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Mrs</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Ms">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>09bc5967-6b4c-4815-ac8e-1a5a5eb8ee03</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Ms</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Professor">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>3bb53320-1cfd-11e1-8bc2-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Professor</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A professor is someone who is a member of the faculty at a college or university.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=professor</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Reverend">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>27a398fa-0ea6-4445-95de-53a32e839b4d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Reverend</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Sir">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>2a5de419-4144-42fe-8e4b-73dca8c54f8d</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Sir</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Associate">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>a27e5ca7-3d20-4272-9054-7db550e2a053</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Associate</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF terms, associate is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Associate" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An associate is a person with subordinate membership in a society, institution, or commercial enterprise.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=associate</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Dame">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>a944b6ae-e2be-40e0-a33e-e5da5db6ea89</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Dame</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Emeritus">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>1e83ced2-47e7-4e01-a7b9-ec78291d979c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Emeritus</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PersonTitles#Colonel">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PersonTitles"/>
+<dc:identifier>d0d64e35-d7dd-443d-8d77-96ee4ad8023b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Colonel</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+</rdf:Description>
+</rdf:RDF>
+	

--- a/vocab/rdf/ProjectOutcomeRelations.rdf
+++ b/vocab/rdf/ProjectOutcomeRelations.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectOutcomeRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>355408c0-4afa-417d-a7cb-642b74c6dff9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project Outcome Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in project initiated results, such as citations or spin-offs, e.g. recorded through the cfProject_OrganisationUnit link entity or with citation counting, being thus project outcome relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ProjectOutcomeRelations#Spin-Off"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectOutcomeRelations#Spin-Off">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ProjectOutcomeRelations"/>
+<dc:identifier>eda28bcc-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Spin-Off</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A spin-out, also known as a spin-off or a starburst, refers to a type of corporate action where a company "splits off" sections of itself as a separate business.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://en.wikipedia.org/wiki/Corporate_spin-off</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ProjectOutputRoles.rdf
+++ b/vocab/rdf/ProjectOutputRoles.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectOutputRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af931-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project Output Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in a cfProject_ResultPublication link entity - being thus project publication roles.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ProjectOutputRoles"/>
+<dc:identifier>eda2b2d8-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Originator</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A originator is someone who creates new things.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=Originator</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ProjectResearchInfrastructureRelations.rdf
+++ b/vocab/rdf/ProjectResearchInfrastructureRelations.rdf
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6df06582-34bd-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Project Research Infrastructure Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfProject_Equipment; cfProject_Service, cfProject_Facility link entities, being thus project infrastructure relation.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#Builton"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#User"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#Construction"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#Development"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#Builton">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations"/>
+<dc:identifier>eda28bc9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Built on</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Built on - is a form of succession - informally expressed.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#User">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations"/>
+<dc:identifier>eda2da00-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">User</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#Construction">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations"/>
+<dc:identifier>eda2da02-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Construction</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations#Development">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ProjectResearchInfrastructureRelations"/>
+<dc:identifier>eda2da03-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Development</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/PublicationStatuses.rdf
+++ b/vocab/rdf/PublicationStatuses.rdf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PublicationStatuses">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>40e90e2f-446d-460a-98e5-5dce57550c48</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Publication Statuses</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The status of the publication in the publishing process.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses#InPreparation"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses#SubmittedforConsideration"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses#InPress"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses#Published"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses#Unpublished"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PublicationStatuses#InPreparation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses"/>
+<dc:identifier>1bb29e6d-d282-415f-920d-9b6148933a35</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In Preparation</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A (planned) output.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PublicationStatuses#SubmittedforConsideration">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses"/>
+<dc:identifier>1c774414-3a42-4e4c-b3c5-04b89202c40f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Submitted for Consideration</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A final draft submitted for consideration.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PublicationStatuses#InPress">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses"/>
+<dc:identifier>da636eb4-efe2-4112-a4ee-7ce4a99e2374</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In Press</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An accepted but not yet published output.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PublicationStatuses#Published">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses"/>
+<dc:identifier>e601872f-4b7e-4d88-929f-7df027b226c9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Published</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">An output available in the public domain (paid or open access or grey literature, and including but not restricted to "public domain works").</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/PublicationStatuses#Unpublished">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/PublicationStatuses"/>
+<dc:identifier>24906a3a-1edd-40f0-aeec-5f0bf4312086</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Unpublished</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A proposed output never put in the public domain.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CIA project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructure.rdf
+++ b/vocab/rdf/ResearchInfrastructure.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>dbdd1fdb-128b-414c-ba2b-fa26a25a4bc6</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme defines the CERIF concept of "Research Infrastructure" composed through the link entities cfEquipment_Classification, cfFacility_Classification, cfService_Classification</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructure#ResearchInfrastructure"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructure#ResearchInfrastructure">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructure"/>
+<dc:identifier>cf7799ea-3477-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of research infrastructure is defined as a term in the vocabulary. A research infrastructure in CERIF terms subsumes the three entities service cfService (cfSrv), equipment cfEquipment (cfEquip) and facility cfFacility (cfFacil); these are logic and physic enitites in the CERIF data model.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A European Research Infrastructure is a facility or (virtual) platform that provides the scientific community with resources and services to conduct top-level research in their respective fields. These research infrastructures can be single-sited or distributed or an e-infrastructure, and can be part of a national or international network of facilities, or of interconnected scientific instrument networks. The infrastructure should: offer top quality scientific and technological performance, that should be recognised as being of European relevance offer access to scientific users from Europe and beyond through a transparent selection process on the basis of excellence have stable and effective management</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Concept; MERIL project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.esf.org/activities/science-policy/research-infrastructures/meril-mapping-of-the-european-research-infrastructure-landscape/what-is-meant-by-research-infrastructures.html</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureAccess.rdf
+++ b/vocab/rdf/ResearchInfrastructureAccess.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>4490bcae-1632-460d-947c-c230130c013b</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Access</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable with the cfResultPublication_Equipment; cfResultPublication_Facility; and cfResultPublication_Service link entities, being thus the documents related to access policy or terms and conditions of the Research Infrastructure.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess#AccessPolicyDocument"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess#AccessTermsandConditions"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess#AccessPolicyDocument">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess"/>
+<dc:identifier>eda2b2dd-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Access Policy Document</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The document specifying the access policy for the equipment, facility or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess#AccessTermsandConditions">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureAccess"/>
+<dc:identifier>80be3ed3-5677-4676-b466-fa9f61d8af42</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Access Terms and Conditions</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The document specifying the access terms and conditions for the equipment, facility or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureCostings.rdf
+++ b/vocab/rdf/ResearchInfrastructureCostings.rdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>1c603df8-6949-4f07-bbc3-3388df7dcd2c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Costings</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfFacility_Measurement; cfEquipment_Measurement; cfService_Measurement link entities, being thus research infrastructure costing.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings#ConstructionCosts"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings#DesignCosts"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings#OperatingCosts"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings#ConstructionCosts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings"/>
+<dc:identifier>eda2da08-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Construction Costs</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings#DesignCosts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings"/>
+<dc:identifier>eda2da09-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Design Costs</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings#OperatingCosts">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureCostings"/>
+<dc:identifier>eda2da0a-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Operating Costs</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureFundingRoles.rdf
+++ b/vocab/rdf/ResearchInfrastructureFundingRoles.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureFundingRoles">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>3fe69a58-34c3-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Funding Roles</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfFunding_Equipment; cfFunding_Service, cfFunding_Facility link entities, being thus funding infrastructure roles.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureFundingRoles#Funder"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureFundingRoles#Funder">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureFundingRoles"/>
+<dc:identifier>eda28bc0-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Funder</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://www.businessdictionary.com/definition/funder.html</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureRelations.rdf
+++ b/vocab/rdf/ResearchInfrastructureRelations.rdf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureRelations">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>4c2f217d-98ad-4c49-bbb0-399e28d7a8c9</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Relations</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfFacility_Service; cfEquipment_Service; cfFacility_Equipment link entities, being thus research infrastructure relations.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureRelations#Provision"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureRelations#Provision">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureRelations"/>
+<dc:identifier>eda2da07-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Provision</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureStatuses.rdf
+++ b/vocab/rdf/ResearchInfrastructureStatuses.rdf
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>1eb17479-09de-49b8-9fed-1a54d697ea1c</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Statuses</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfEquipment_Classification; cfFacility_Classification; cfService_Classification link entities, being thus research infrastructure states.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses#UnderConstruction"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses#BeingUpgraded"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses#InOperation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses#UnderConstruction">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses"/>
+<dc:identifier>eda2da04-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Under Construction</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses#BeingUpgraded">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses"/>
+<dc:identifier>eda2da05-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Being Upgraded</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses#InOperation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureStatuses"/>
+<dc:identifier>eda2da06-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In Operation</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureTypes.rdf
+++ b/vocab/rdf/ResearchInfrastructureTypes.rdf
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>759af93d-34ae-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Types</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable in the cfEquipment_Classification, cfService_Classification, cfFacility_Classification link entities, being thus infrastructure types.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Distributed"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Network"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Virtual"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Cluster"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Singlelocation"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Distributed">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes"/>
+<dc:identifier>eda2d9f9-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Distributed</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A distributed RI is constituted by geographically distributed implementations/facilities but managed by a single body. Thus, a distributed RI is thus considered as a single RI, modelled in CERIF as a tree of facilities connected to the Facility entity representing the entire RI via recursive cfFacility_Facility relationships with appropriate semantics (e.g. isPartOf) while the RI is connected with its managing body through the cfOrgUnit_Facil link entity.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Network">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes"/>
+<dc:identifier>eda2d9fa-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Network</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A network of RIs comprises several RIs connected in some respect, but each one with its own governance/management body. The relationships between RIs in a network are modelled in CERIF using the CERIF Semantic Layer reference from within the cfFacil_Class link entity (Class=Network, role expression is a network).</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Virtual">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes"/>
+<dc:identifier>eda2d9fb-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Virtual</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A virtual RI is defined as e-infrastructure, either a distributed e‐infrastructure that connects several RIs (databases, HP computers, facilities, etc) or a single‐sited electronic RI (e-library, e-archive, data repository, etc).  </dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Cluster">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes"/>
+<dc:identifier>eda2d9fc-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Cluster</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">A cluster is a grouping of RIs based on certain similarities (scientific domain, geographical region). A cluster of RIs may be supported in some way or funded, e.g. by industry entities. A cluster is modelled in CERIF as a virtual organisation through the cfOrgUnit entity connected with the individual RIs belonging to the cluster with a cfOrgUnit_Facil link entity.</dc:description>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes#Singlelocation">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureTypes"/>
+<dc:identifier>eda2d9fd-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Single location</rdfs:label>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchInfrastructureUsage.rdf
+++ b/vocab/rdf/ResearchInfrastructureUsage.rdf
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureUsage">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>47761818-0e55-41a6-a21e-1e72f9a8922e</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Infrastructure Usage</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme contains CERIF vocabulary terms applicable with the cfResultPublication_Equipment; cfResultPublication_Facility; and cfResultPublication_Service link entities, being thus the documents related to usage of the Research Infrastructure.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureUsage#UsageDocument"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchInfrastructureUsage#UsageDocument">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchInfrastructureUsage"/>
+<dc:identifier>eda2b2de-34c5-11e1-b86c-0800200c9a66</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Usage Document</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The document specifying the usage for the equipment, facility or service.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">MERIL project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/ResearchOutput.rdf
+++ b/vocab/rdf/ResearchOutput.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchOutput">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>6832797c-2f56-4336-b4ff-dc0ba2275dfa</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Output</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">This scheme defines the CERIF concept of "Research Output" composed through the link entities cfResultPublication_Classification, cfResultPatent_Classification, cfResultProduct_Classification</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/ResearchOutput#ResearchOutput"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/ResearchOutput#ResearchOutput">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/ResearchOutput"/>
+<dc:identifier>627e286f-a8ae-46c6-891e-0218e6b2f1a8</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Research Output</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">In CERIF, the concept of research output is defined as a term in the vocabulary. Research output in CERIF terms subsumes results such as publications cfResultPublication (cfResPubl), patent cfResultPatent (cfResPat) and product cfResultProduct (cfResProd); these are logic and physic enitites in the CERIF data model.</dc:description>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The act of becoming formally connected or joined; a social or business relationship.</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group; HEFCE REF2014 Output Information Requirements; RMAS Vocabulary; CASRAI Dictionary</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">CERIF Task Group</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">http://wordnetweb.princeton.edu/perl/webwn?s=affiliation</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/rdf/VerificationStatuses.rdf
+++ b/vocab/rdf/VerificationStatuses.rdf
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns="https://w3id.org/cerif/vocab/">
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/VerificationStatuses">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassificationScheme"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+<dc:identifier>2ad984e8-33ae-4f0b-927e-d292c28750e3</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Verification Statuses</rdfs:label>
+<dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">The state of verification, deduced from a date-time (e.g. for outputs) where raw data may have been imported from external sources or for information about staff which might be re-validated on annual basis.</dc:description>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/VerificationStatuses#Checked"/>
+<skos:hasTopConcept rdf:resource="https://w3id.org/cerif/vocab/VerificationStatuses#Unchecked"/>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/VerificationStatuses#Checked">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/VerificationStatuses"/>
+<dc:identifier>c3c8c96f-cc0f-47e6-9c6d-4f86949ab984</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Checked</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">checked</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+<rdf:Description rdf:about="https://w3id.org/cerif/vocab/VerificationStatuses#Unchecked">
+<rdf:type rdf:resource="https://w3id.org/cerif/model#cfClassification"/>
+<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+<skos:topConceptOf rdf:resource="https://w3id.org/cerif/vocab/VerificationStatuses"/>
+<dc:identifier>9b5e9d79-c332-40cb-b888-8a37bdef9f1f</dc:identifier>
+<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">Unchecked</rdfs:label>
+<skos:definition rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">not yet checked</skos:definition>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS project</dc:source>
+<dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string" xml:lang="en">RMAS Vocabulary</dc:source>
+</rdf:Description>
+</rdf:RDF>

--- a/vocab/xml/ActivityFinanceCategories.xml
+++ b/vocab/xml/ActivityFinanceCategories.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>c855b95d-bf01-44eb-a1f3-17b0f0901599</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Finance Categories</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The type of cost of an activity.</cfDescr>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Finance Categories; Activity Subtypes; CERIF Entities -->
+      <!-- usage with CERIF: cfFacil_Class; Proj_Meas; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfFacil -->
+      <cfClassId>cf7799e7-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Facility</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of Facility (also Research Facility) is physically (cfFacil) and logically (cfFacility) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Facil), organisations (cfOrgUnit_Facil), classification systems (cfFacil_Class), projects (cfProj_Facil). In the physical CERIF data model, the classification of types for facility happens with the cfFacil_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning facility types to facility records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The full economic cost associated with the running of the institutional research facilities and equipment used in an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A facility is a space or equipment necessary for conducting research (CERIF Entity). The full economic cost associated with the running of the institutional research facilities and equipment used in an activity (Activity Finance Category). The specification, procurement and installation of a facility (Activity Subtype).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group; http://www.jcpsg.ac.uk/guidance/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Finance Categories; CERIF Entities -->
+      <!-- usage with CERIF: cfEquip_Class; cfProj_Meas; cfProj_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfEquip -->
+      <cfClassId>cf7799e8-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Equipment</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of equipment is physically (cfEquip) and logically (cfEquipment) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Equip), organisations (cfOrgUnit_Equip), classification systems (cfEquip_Class), projects (cfProj_Equip). In the physicial CERIF data model, the classification of types for equipment happens with the cfEquip_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning equipment types to equipment records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The costs associated with the purchase of equipment normally above a price threshold, e.g 1.000 GBP (Activity Finance Category). The specification, procurement and installation of equipment Activity Subtype).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Equipment is an instrumentality needed for undertaking or to perform a service (CERIF Entity). The costs associated with the purchase of equipment normally above a price threshold, e.g 1.000 GBP (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=equipment; RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types; Person Project Engagements; Activity Finance Categories -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfProj_Meas -->
+      <cfClassId>8adcdf20-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Technician</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is technician at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has technician</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, technician is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Technician" identified by its cfClassificationIdentifier (a uuid) and reused inlink entities. (CERIF Task Group) A permanent Research staff. (RMAS project)</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The full economic cost associated with pool technicians used in the activity (Activity Finance Category). Someone, whose duties include the construction, maintenance and operation of the equipment involved in laboratory research; the preparation of samples that constitute the raw material for experiments; the running of those experiments; and the recording, presentation and - on occations - some of the analysis and interpretation of the data that is produced. In undertaking these tasks, technicians work closely with academic researchers and make an indispensible contribution to the production of scientific knowledge, and through formal, and, in particular, informal contributions to the teaching of practical skills, they help to educate students (http://www.kcl.ac.uk/sspp/departments/management/people/academic/lewisgatsbyreport.pdf).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A technician is someone known for high skill in some intellectual or artistic technique.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=technician</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories; Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Meas; cfProj_Class -->
+      <cfClassId>fe3ef479-0a35-4b3e-93e8-f54800c98857</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Travel</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The costs associated with travel and subsistence (Activity Finance Category). A physical networking activity normally associated with a single or short series of visits (Activity Subtypes).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>77a49137-eb32-4a30-9fff-14ce3eb4413f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Staffing Existing</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The costs associated with staff under an existing employment contract including salary and employer tax and pension contributions (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>f81be4da-59bb-4718-949a-6e47b0fa2868</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Staffing New</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The costs associated with staff specifically employed to work on the activity (i.e. additional staff) including salary and employer tax and pension contributions (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>fa67d8ad-46eb-499a-9b9b-2b681b3d9485</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Consumables</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The costs associated with small cost items, e.g. a office stationary, software (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>5845512f-64ce-4cbe-b4c7-4c8794ab0242</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Other Non-Staffing</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The costs associated with any other directly incurred items (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>dd9bb430-17b3-4064-bd1f-528237bd4e48</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Payment-To-Partner</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The funding allocated from the funder to project partner, e.g. funds received from the funder by the co-ordinator on behalf of the partners (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>fb8a8939-0659-4cdf-b186-f8430566e845</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Estates</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The full economic cost associated with the running of the institutional physical estate (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>6d81aa21-e667-4778-bc97-c59e0cc3fa18</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Indirect Costs</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The full economic cost associated with the other indirect costs associated with research, e.g. a proportion of HR, Finance, IT, Library, etc. ((Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>b2aeb46d-3ae2-4df6-aaad-079a339da9d2</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">fEC Balancing Amount</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The difference between the full economic costs of an activity and the budget/income/expenditure, e.g. for an 80%-funded activity of 50.000 this would be the 10.000 amount not received from the funder (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivityFinanceCategoryAmounts.xml
+++ b/vocab/xml/ActivityFinanceCategoryAmounts.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>63468e45-3055-4ba8-b644-6262c96f62bd</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Finance Category Amounts</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The income or expenditure (actual, committed or budgeted) against a finance category for the activity (Research project).</cfDescr>
+    <cfClass>
+      <!-- class schemes: Activity Finance Category Amounts -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>7655a603-a4d7-4b92-8c87-d7e767d2c7a7</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Income-Budget</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The amount of income expected from the funder for an activity, e.g the amount awarded by the funder (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Category Amounts -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>d2c2d808-bd02-4ffc-8a76-76c3d0c9cc1f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Expenditure-Budget</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The amount of expected expenditure necessary to undertake the activity, e.g. the full economic cost (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Category Amounts -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>df1c9f14-6b87-43a1-9a5a-2d0ade88ad0b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Income-Commitment</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The amount of income expected from the funder for an activity but not yet received (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Category Amounts -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>8db551b3-e630-48a0-9164-d177f4ec3602</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Expenditure-Commitment</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The amount of expenditure committed but not yet spent, e.g an order placed but not yet paid for ((Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Category Amounts -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>df27417c-bb3c-4881-9a46-cc6403b2ca39</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Income-Actual</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The amount of actual income received from the funder for an activity (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Category Amounts -->
+      <!-- usage with CERIF: cfProj_Meas -->
+      <cfClassId>fe050c5b-2760-4c67-b5b6-6252257b7c61</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Expenditure-Actual</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The amount of actual expenditure on an activity, e.g. the cost incurred in undertaking the research (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivityFundingTypes.xml
+++ b/vocab/xml/ActivityFundingTypes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>a620795c-7015-482e-bdba-43a761b337a1</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Funding Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The types of funding mechanism.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Activity Funding Types -->
+      <!-- usage with CERIF: cfProj_Fund -->
+      <cfClassId>17273adf-2529-49c3-a40a-21712d67128c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Award</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The funding mechanism where discretionary funds are awarded based on an achievement (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Funding Types -->
+      <!-- usage with CERIF: cfProj_Fund -->
+      <cfClassId>4e664be9-100d-481c-b60f-b62a94078bac</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Grant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The funding mechanism where a proposed activity is submitted for consideration and where the funding is approved (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Funding Types -->
+      <!-- usage with CERIF: cfProj_Fund -->
+      <cfClassId>125a3e36-a300-449f-abfa-11178d87ba63</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contract</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The funding mechanism where a proposed activity is submitted for consideration and where the funding is approved and will be allocated on successful delivery of the proposed outputs (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivityOutputContributions.xml
+++ b/vocab/xml/ActivityOutputContributions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>ad87a6e2-5093-4550-86da-ead48cc3f385</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Output Contributions</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in e.g. the cfProject_ResultPublication; cfProject_ResultPatent; cfProject_ResultProduct; cfProject_Event cflink entity, being thus an activity output contribution.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivityStatuses.xml
+++ b/vocab/xml/ActivityStatuses.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af93a-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Statuses</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfProject_Classification link entity, being thus Activity states.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>8dc4b088-6e93-4d3a-ab67-60c0d287868b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conceptualised</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The definition of a planned activity is being developed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>edb73a76-2b48-4eca-991e-1b0b6fbe524a</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Internal-Reviewed</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The definition of a planned activity has been sucessfully reviewed including for example a peer review, ethical review, health and safety review, etc. If not sucessfully reviewed, then the proposal needs adjustment for internal re-review or might change status to not submitted.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>20a14a62-85b2-42fe-bd46-d9f07a752abc</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Submitted</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The proposed activity has been submitted to the proposed funder for consideration.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>444ababa-bfe8-42fc-af0c-15464545ef98</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Not Submitted</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The proposed activity has not been and is not expected to be submitted to a funder for consideration.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>eda2b2e0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Awarded</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in awarding state</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">The state of awarded is to give as judged due or on the basis of merit. The funder has agreed to fund the proposed activity.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://wordnetweb.princeton.edu/perl/webwn?s=Award</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>f97f3ccd-13c0-46ce-9cb3-98ebb58f39fd</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Rejected</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project; CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in rejected state</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">The funder rejected the proposed activity. The state of refused is to refuse to let have.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://wordnetweb.princeton.edu/perl/webwn?s=Award</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>0bb4df81-4e9a-41ae-947c-5ae3bde26abd</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Assumed Unsuccessful</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The funder has not (yet) responded although the elapsed time since submission implies that the proposal has not been successful.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>bfcdfa1c-6d27-4012-9468-1c91cecbba45</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Withdrawn</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The funder has agreed to fund the proposed activity but the activity will not proceed (e.g. terms of contract are not acceptable, researchers left institution, etc.).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Statuses -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>276a4f0c-6729-47df-b8d3-7cd1cb3c7e67</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Closed</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The activity is considered completed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivityStructure.xml
+++ b/vocab/xml/ActivityStructure.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af930-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Structure</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfProject_Project link entity, being thus an activity structure.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Structure; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfProj_Proj; cfProj_Equip; cfProj_Facil; cfProj_Srv; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResPubl; cfResProd_ResProd; cfResPat_ResPat; -->
+      <cfClassId>eda28bc9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Built on</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is built on</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has built</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Built on - is a form of succession - informally expressed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bca-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Successor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is successor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has successor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A successor is someone who, or something which succeeds or comes after.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Successor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bcb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Predecessor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is predecessor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has predecessor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Something that precedes and indicates the approach of something or someone.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Structure; Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfProj_Proj; cfOrgUnit_OrgUnit -->
+      <cfClassId>eda2b2d7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Cooperation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in cooperation with</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has cooperation</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A cooperation is the collaborative work on a common enterprise or project.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivitySubtypes.xml
+++ b/vocab/xml/ActivitySubtypes.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>794234b8-25bb-46df-9d26-ae660bca64bc</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Subtypes</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The subtypes of an activity used for more specific or finer grained analysis.</cfDescr>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Subtypes; CERIF Entities -->
+      <!-- usage with CERIF: cfOrgUnit_Class; cfProject_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfOrgUnit -->
+      <cfClassId>cf7799e2-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Organisation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of organisation is physically (cfOrgUnit) and logically (cfOrganisationUnit) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. person (cfPers_OrgUnit), events (cfOrgUnit_Event), classification systems (cfOrgUnit_Class), projects (cfProj_OrgUnit). In the CERIF vocabulary, we introduce the concept of organisation. In the physical CERIF data model, the classification of types for organisations happens with the cfOrgUnit_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning organisation types to organisation records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">Organising an event (e.g conference) (Activity Subtype).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An organization (or organisation — see spelling differences) is a social group which distributes tasks for a collective goal. The word itself is derived from the Greek word organon, itself derived from the better-known word ergon - as we know `organ` - and it means a compartment for a particular job.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Organization; RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Finance Categories; Activity Subtypes; CERIF Entities -->
+      <!-- usage with CERIF: cfFacil_Class; Proj_Meas; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfFacil -->
+      <cfClassId>cf7799e7-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Facility</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of Facility (also Research Facility) is physically (cfFacil) and logically (cfFacility) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Facil), organisations (cfOrgUnit_Facil), classification systems (cfFacil_Class), projects (cfProj_Facil). In the physical CERIF data model, the classification of types for facility happens with the cfFacil_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning facility types to facility records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The full economic cost associated with the running of the institutional research facilities and equipment used in an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A facility is a space or equipment necessary for conducting research (CERIF Entity). The full economic cost associated with the running of the institutional research facilities and equipment used in an activity (Activity Finance Category). The specification, procurement and installation of a facility (Activity Subtype).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group; http://www.jcpsg.ac.uk/guidance/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Types; Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class; cfProj_Class -->
+      <cfClassId>67f2c93f-37c9-4311-99e7-61d40d53b265</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Networking</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity which brings together either physically or virtually groups of people, normally over a period of time to meet and exchange information and good practice.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>0bd2d47a-8688-4758-a63c-45e76825a0f6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Project</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A project with a specific set of anticipated research outputs to be produced over a specific time-frame.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>c0441e0d-42e4-4dd1-84bc-9cd345b911f5</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contract Research</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A project funded for an expected outcome (normally specified by the funder).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>28de21fc-ab80-49dc-8725-41d033e81028</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Early Career Research Project</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A project undertaken by an early career researcher, for example someone in the first four years of their academic post.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>f81c03f9-7d15-4f61-90e6-bbb5c38c9a6c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Consultancy</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A specific bounded (time and specification) contribution to an activity.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>fb837c4d-73da-448c-a554-383d671bb3eb</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Commercialisation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity to (or to support) the transfer of resarch outputs or outcomes into the private sector.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>2a527079-481f-491a-8e3a-dbc79b271c48</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Continuing Professional Development</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The support for the career development of Researchers, Research Students or Research Leaders.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>6ee92d54-322f-4a55-b2c6-4388ad890754</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Enterprise</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The activity to support working with the private sector.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>7b20769e-cbf6-4955-9844-bdb6b1cd2bf6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">KTP</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The specific activity type defined by the technology strategy board of the UK government.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>6cad7850-82ea-42d6-9a7c-fbcc6753848e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Programme Grant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A large-scale activity designed to comprise a number of projects.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>1d4e7a48-d5f9-427a-bd16-e5b503967071</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Attendance</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Attending an event (e.g conference).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>6cc796c4-84f4-448c-9018-7efc47197627</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Hosting</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Hosting an event (e.g conference).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>bd95c4c6-7882-400c-bde9-b20df6f4f87e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Specified Named Person</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A fellowship awarded to an individual.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>ee8f08de-b0be-4e2b-a90c-63d08433a56d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">General Fellowship</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A fellowship awarded to an institution for which an individual can subsequently apply to.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Finance Categories; Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Meas; cfProj_Class -->
+      <cfClassId>fe3ef479-0a35-4b3e-93e8-f54800c98857</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Travel</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The costs associated with travel and subsistence (Activity Finance Category). A physical networking activity normally associated with a single or short series of visits (Activity Subtypes).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes; Event Types -->
+      <!-- usage with CERIF: cfProj_Class; cfEvent_Class -->
+      <cfClassId>33fd9fc9-48b5-41c5-a2f6-b97c6996e432</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Workshop</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A physical or virtual networking activity bringing people together for a single gathering.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>fe88ae1b-4eaa-43e6-b8df-479cc0609b8b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Building</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The specification, procurement and installation of buildings.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>37a7dad6-2487-4df8-9b41-d6c6663bba4b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Collaborative</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">(The work undertaken by a person during) a funded research degree which involves an external agency as part of or host to the research work (e.g. a research council collaborative doctoral award).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>65c07ebe-0836-49af-be78-82a36a629b30</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">General Studentship</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">(The work undertaken by a person during) a funded research degree.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>08431e7e-4a62-42e3-80d7-5941126752c1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Block-Grant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">(The work undertaken by a number of people during) a block of funded research degrees (e.g. a research council block-grant partnership).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ActivityTypes.xml
+++ b/vocab/xml/ActivityTypes.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>47c7efda-bb6e-44ad-bfd3-8be5b6b5cd02</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Activity Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The types of Research activity.</cfDescr>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Types; CERIF Entities -->
+      <!-- usage with CERIF: cfProj_Class; cfProj_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfProj -->
+      <cfClassId>cf7799e1-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Project</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of project is physically (cfProj) and logically (cfProject) defined as an entity in an ERM, represented by basic attributes and through maintaining relationships with other entities: projects (cfProj_Proj), classification systems (cfProj_Class), persons (cfProj_Pers), indicators (cfProj_Indic), measurements (cfProj_Meas). In the CERIF vocabulary, we introduce the concept of project. In the physical CERIF data model, the classification of types for projects happens with the cfProj_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning project types to project records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">A project in business and science is typically defined as a collaborative enterprise, frequently involving research or design, that is carefully planned to achieve a particular aim. Projects can be further defined as temporary rather than permanent social systems that are constituted by teams within or across organizations to accomplish particular tasks under time constraints.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Project</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity with a specific set of anticpated outputs to be produced over a speficic time-frame.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Types; Output Types; Event Types -->
+      <!-- usage with CERIF: cfProj_Class; cfEvent_Class; Event_Class -->
+      <cfClassId>909ea9bd-e460-497e-8950-9ad306675ae9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity that brings together people to discuss topics around an agreed theme.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Types -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>d7fe4a84-93a2-46f1-b1fa-165d518fba47</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Fellowship</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An award for an individual allowing to undertake generic or specific research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Types; Activity Subtypes -->
+      <!-- usage with CERIF: cfProj_Class; cfProj_Class -->
+      <cfClassId>67f2c93f-37c9-4311-99e7-61d40d53b265</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Networking</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity which brings together either physically or virtually groups of people, normally over a period of time to meet and exchange information and good practice.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Types -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>4af214d4-579f-4396-aef6-9e3ce879c6be</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Infrastructure</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity to develop or maintain equipment, facilities, services or buildings.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Types -->
+      <!-- usage with CERIF: cfProj_Class -->
+      <cfClassId>f74a1e84-6c96-4cab-bd51-da931c9f226d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Studentship</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">(The work undertaken by a person during) a funded research degree.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/CERIFEntities.xml
+++ b/vocab/xml/CERIFEntities.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6e0d9af0-1cd6-11e1-8bc2-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">CERIF Entities</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains defined CERIF concepts such as person, organisation, research infrastructure (being not only a 1:1 representation of the CERIF entities), but even more, e.g. research infrastructure subsumes facilty, equipment and service and output subsumes publication, patent, and product in CERIF.</cfDescr>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfPers_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfPers -->
+      <cfClassId>cf7799e0-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Person</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of person is physically (cfPers) and logically (cfPerson) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Pers), qualifications (cfPers_Qual), events (cfPers_Event), classification systems (cfPers_Class), countries (cfPers_Country).In the CERIF vocabulary, we introduce the concept of person. In the physical CERIF data model, the classification of types for persons happens with the cfPers_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning person types to person records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A person (plural: persons or people; from Latin: persona, meaning "mask") is a being, such as a human, that has certain capacities or attributes constituting personhood, the precise definition of which is the subject of much controversy.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Person</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Types; CERIF Entities -->
+      <!-- usage with CERIF: cfProj_Class; cfProj_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfProj -->
+      <cfClassId>cf7799e1-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Project</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of project is physically (cfProj) and logically (cfProject) defined as an entity in an ERM, represented by basic attributes and through maintaining relationships with other entities: projects (cfProj_Proj), classification systems (cfProj_Class), persons (cfProj_Pers), indicators (cfProj_Indic), measurements (cfProj_Meas). In the CERIF vocabulary, we introduce the concept of project. In the physical CERIF data model, the classification of types for projects happens with the cfProj_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning project types to project records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">A project in business and science is typically defined as a collaborative enterprise, frequently involving research or design, that is carefully planned to achieve a particular aim. Projects can be further defined as temporary rather than permanent social systems that are constituted by teams within or across organizations to accomplish particular tasks under time constraints.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Project</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity with a specific set of anticpated outputs to be produced over a speficic time-frame.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Subtypes; CERIF Entities -->
+      <!-- usage with CERIF: cfOrgUnit_Class; cfProject_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfOrgUnit -->
+      <cfClassId>cf7799e2-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Organisation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of organisation is physically (cfOrgUnit) and logically (cfOrganisationUnit) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. person (cfPers_OrgUnit), events (cfOrgUnit_Event), classification systems (cfOrgUnit_Class), projects (cfProj_OrgUnit). In the CERIF vocabulary, we introduce the concept of organisation. In the physical CERIF data model, the classification of types for organisations happens with the cfOrgUnit_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning organisation types to organisation records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">Organising an event (e.g conference) (Activity Subtype).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An organization (or organisation — see spelling differences) is a social group which distributes tasks for a collective goal. The word itself is derived from the Greek word organon, itself derived from the better-known word ergon - as we know `organ` - and it means a compartment for a particular job.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Organization; RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfResPat_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfResPat -->
+      <cfClassId>cf7799e3-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Patent</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of patent is physically (cfResPat) and logically (cfResultPatent) defined as an entity in an ERM, described through basic attributes and through In the CERIF vocabulary, we introduce the concept of patent. In the physical CERIF data model, the classification of types for patents happens with the cfResPat_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning patent types to patent records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A patent ( /ˈpætənt/ or /ˈpeɪtənt/) is a form of intellectual property. It consists of a set of exclusive rights granted by a sovereign state to an inventor or their assignee for a limited period of time in exchange for the public disclosure of an invention.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Patent</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfResProd_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfResProd -->
+      <cfClassId>cf7799e4-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Product</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of product is physically (cfResProd) and logically (cfResultProduct) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_ResProd), organisations (cfOrgUnit_ResProd), classification systems (cfResProd_Class), projects (cfProj_ResProd). "The entity product in CERIF has often caused confusion, it was maybe not stressed enough, that a cerif product is considered a result in general, achieved through some effort - and not at all is it a commercial or a physical product only. It was intended also to represent i.e. software or 'research data'. The Australian National Data Services aims at collecting definitions for clarifiying the concept of ""research data"". In CERIF, cfResProd (cfResultProduct) is an entity in the ERM. In the CERIF vocabulary, we introduce the concept of product. In the physical CERIF data model, the classification of types for products happens with the cfProduct_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning product types to product records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">In CERIF, the cfResultProduct (cfResProd) entity is meant conceptually to represent research output, such as an artefact, a device, a performance, an exhibition.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/product</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfResPubl_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfResPubl -->
+      <cfClassId>cf7799e5-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Publication</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of publication is physically (cfResPubl) and logically (cfResultPublication) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_ResPubl), organisations (cfOrgUnit_ResPubl), classification systems (cfResPubl_Class), projects (cfProj_ResPubl). "In CERIF, cfResPubl (cfResultPublication) is an entity in the ERM. In the CERIF vocabulary, we introduce the concept of publication. Behind the publication concept in research there are moslty peer-reviewed publications (journal articles, conference articles). More and more, there are also other publication types of interest in the scientific domain, so-called 'Grey Literature', and multiple schemes are available to collect publication types. In the physical CERIF data model, the classification of types for publications happens with the cfResPubl_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning publication types to publication records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Collection of information records that, in combination, represent a full and up-to-date history of research or scholarly published outputs resulting from, or related to, the person's research activities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/1.1.0/contributions/outputs/publications</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfFund_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfFund -->
+      <cfClassId>cf7799e6-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funding</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of funding is physically (cfFund) and logically (cfFunding) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Fund), organisations (cfOrgUnit_Fund), classification systems (cfRund_Class), projects (cfProj_Fund). In the CERIF vocabulary, we introduce the concept of funding. In the physical CERIF data model, the classification of types for funding happens with the cfFund_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning funding types to funding records.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Funding is an amount of money or an inkind equivalent value.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Finance Categories; Activity Subtypes; CERIF Entities -->
+      <!-- usage with CERIF: cfFacil_Class; Proj_Meas; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfFacil -->
+      <cfClassId>cf7799e7-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Facility</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of Facility (also Research Facility) is physically (cfFacil) and logically (cfFacility) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Facil), organisations (cfOrgUnit_Facil), classification systems (cfFacil_Class), projects (cfProj_Facil). In the physical CERIF data model, the classification of types for facility happens with the cfFacil_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning facility types to facility records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The full economic cost associated with the running of the institutional research facilities and equipment used in an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A facility is a space or equipment necessary for conducting research (CERIF Entity). The full economic cost associated with the running of the institutional research facilities and equipment used in an activity (Activity Finance Category). The specification, procurement and installation of a facility (Activity Subtype).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group; http://www.jcpsg.ac.uk/guidance/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; Activity Finance Categories; CERIF Entities -->
+      <!-- usage with CERIF: cfEquip_Class; cfProj_Meas; cfProj_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfEquip -->
+      <cfClassId>cf7799e8-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Equipment</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of equipment is physically (cfEquip) and logically (cfEquipment) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Equip), organisations (cfOrgUnit_Equip), classification systems (cfEquip_Class), projects (cfProj_Equip). In the physicial CERIF data model, the classification of types for equipment happens with the cfEquip_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning equipment types to equipment records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The costs associated with the purchase of equipment normally above a price threshold, e.g 1.000 GBP (Activity Finance Category). The specification, procurement and installation of equipment Activity Subtype).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Equipment is an instrumentality needed for undertaking or to perform a service (CERIF Entity). The costs associated with the purchase of equipment normally above a price threshold, e.g 1.000 GBP (Activity Finance Category).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=equipment; RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfSrv_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfSrv -->
+      <cfClassId>cf7799e9-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Service</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of serive is physically (cfSrv) and logically (cfService) defined as an entity in an ERM, described through basic attributes and through semantically neutral relationships with e.g. persons (cfPers_Srv), organisations (cfOrgUnit_Srv), classification systems (cfSrv_Class), projects (cfProj_Srv). In the CERIF vocabulary, we introduce the concept of service. In the physical CERIF data model, the classification of types for service happens with the cfSrv_Class entity, where a type is represented by a classification term (cfTerm) identified by its cfClassificationIdentifier (a uuid), and reused at instance level for assigning service types to service records."</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The specification, procurement and installation of a service or the maintenance of existing equipment, facilities and buildings.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A service is an exchange for money or other commodities where an enduser receives support from a supplier.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfCite_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfCite -->
+      <cfClassId>68aa07f0-34c9-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Citation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the citation entity is used for publication references (citations) to outside of the current information system. Otherwise, citation counts may be deduced from physical publication-publication relationships, i.e. cfResPubl_ResPubl (physical) or cfResultPublication_cfResultPublication (logical) and stored as a measurement cfResPubl_Meas (cfResultPublication_Measurement).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A citation is an acknowledgment, credit, reference, mention, quotation (a short note recognizing a source of information or of a quoted passage).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=citation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfCV_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfCV -->
+      <cfClassId>68aa07f1-34c9-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Curriculum Vitae</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the CV entity is used for curriculum vitae information references.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A curriculum vitae (cv) is a summary of your academic and work history.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=cv</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfEAddr_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfEAddr -->
+      <cfClassId>68aa07f2-34c9-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Electronic Address</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of electronic address is physically (cfEAddr) and logically (cfElectronicAddress) defined as an entity in the ERM, described through basic attributes and through semantically neutral relationships with persons (cfPers_EAddr), organisations (cfOrgUnit_EAddr), classification systems (cfEAddr_Class).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An electronic address is a computer address, reference ((computer science) the code that identifies where a piece of information is stored).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=address</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfPAddr_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfPAddr -->
+      <cfClassId>68aa07f3-34c9-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Postal Address</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of physical address is physically (cfPAddr) and logically (cfPhysicalAddress) defined as an entity in the ERM, described through basic attributes and through semantically neutral relationships with persons (cfPers_PAddr), organisations (cfOrgUnit_PAddr), classification systems (cfPAddr_Class).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An address is the place where a person or organization can be found or communicated with.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=address</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfEvent_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfEvent -->
+      <cfClassId>68aa07f4-34c9-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Event</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of event is physically and logically defined as an entity cfEvent in the ERM, described through basic attributes and through semantically neutral relationships e.g. with persons (cfPers_Event), organisations (cfOrgUnit_Event), classification systems (cfEvent_Class).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An event is something that happens at a given place and time.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=event</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfMedium_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfQual -->
+      <cfClassId>a9332fbf-e5a9-430f-8e78-26bc3610dfe3</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Medium</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of medium is physically and logically defined as an entity cfMedium in the ERM, described through basic attributes and through semantically neutral relationships e.g. with persons (cfPers_Event), organisations (cfOrgUnit_Event), classification systems (cfEvent_Class).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A means or instrumentality for storing or communicating information</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=medium</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfQual_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfMedium -->
+      <cfClassId>68aa07f5-34c9-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Qualification</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of qualification is physically (cfPAddr) and logically (cfPhysicalAddress) defined as an entity in the ERM, described through basic attributes and through semantically neutral relationships with persons (cfPers_Qual) and classification systems (cfQual_Class).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A qualification is an attribute that must be met or complied with and that fits a person for something.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=qualification</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <!-- cerifERM-Entity: cfFedId -->
+      <cfClassId>a1e51365-b7c4-4bdb-bbd1-0530840148be</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Federated Identifier</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the cfFederatedIdentifier entity is an hybrid entity in the sense that it connects the internal world with an outside world, of which we do not know what can be assumed to be known. For consistency, this entity has ist own cfFederatedIdentifier identifier - namely in short cfFedIdId as an ID and primary key (PK). Finally, the entity has the cfInstanceIdentifier as a character, identifying the record for which this federate identifier is required - in short cfFedInstId. These two just introduced identifiers, in sort cfFedIdId, and cfFedIdInstId represent the internal world of the system. However, following the CERIF link entity style, the linked entity identifier is also required; pointing to the outside world, namely this is the cfFedId or cfFederatedIdentifier as such. It can possibly have a role that is applicable with Relation. We assume that currrently the only role appied is "same as", where for future applications it may be useful to have the usual cfClassId/cfClassSchemeId reference optionally available (e.g. for possible constraints such as - the fed-id-link is valid only for a person in the role of an author). However, especially with the CERIF XML, we currently recommend to omit it, because the cfFedId entity is embeded in the base entity and thus, the same-as attribute is implictly known from the structure of the XML record (see examples and specification documents).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A federated identifier supports with additional information sources extractions.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfMeas_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfMeas -->
+      <cfClassId>1cc0fbd8-a160-41df-9af8-d436e6a5296f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Measurement</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; MICE project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the cfMeasurement entity has been introduced in the context of Impact, which in CERIF is an indicator cfIndicator. In CERIF, a measurement can thus be linked to an indicator through the link entity cfIndicator_Measurement (CERIF link entities are neutral in reading directions), incorporating the usual link entity construct, i.e. Semantic Layer references.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">http://mice.cerch.kcl.ac.uk/?p=71</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://mice.cerch.kcl.ac.uk/?p=15; http://en.wikipedia.org/wiki/Performance_indicator</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A measurement is the dimension, quantity, or capacity determined by measuring.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/measurement</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfIndic_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfIndic -->
+      <cfClassId>ed96ef79-f77d-4aaf-8c19-f727bbb49937</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Indicator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M; MICE project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the cfIndicator entity has been introduced in the context of Impact. In CERIF, an indicator can be linked to a measurement through the link entity cfIndicator_Measurement (CERIF link entities are neutral in reading directions), incorporating the usual link entity construct, i.e. Semantic Layer references.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">http://mice.cerch.kcl.ac.uk/?p=71</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://mice.cerch.kcl.ac.uk/?p=15; http://en.wikipedia.org/wiki/Performance_indicator</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An indicator can be defined as something that helps us to understand where we are, where we are going and how far we are from the goal. Therefore it can be a sign, a number, a graphic and so on. It must be a clue, a symptom, a pointer to something that is changing. Indicators are presentations of measurements. They are bits of information that summarize the characteristics of systems or highlight what is happening in a system. A more rigorous definition is given by the International Institute for Sustainable Development (IISD): " An indicator quantifies and simplifies phenomena and helps us understand complex realities. Indicators are aggregates of raw and processed data but they can be further aggregated to form complex indices." Example of traditional indicators or indices used in measuring the social, economic and environmental welfare are: the Gross National Product, the unemployment rates, the price index, the life expectancy (ESEMPIO DI INDICATORE AMBIENTALE)</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities; CERIF Entities -->
+      <!-- usage with CERIF: cfClass_Class; cfFedId_Class -->
+      <!-- cerifERM-Entity: cfClass -->
+      <cfClassId>613b117e-980e-4051-8876-8524cd498caf</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Classification</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">In CERIF, the cfClassification (cfClass) entity is of one of the main entities in the Semantic Layer. Its internal identifier cfClassId is used for references from within all CERIF link entities. It has a recursive entity cfClassification_Classification (cfClass_Class) which is formally also a link entity.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: CERIF Entities -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <!-- cerifERM-Entity: cfClassScheme -->
+      <cfClassId>4c93b3b2-d5ff-442c-9b28-4a028305bcf1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Classification Scheme</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF ER-M</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">In CERIF, the cfClassificationScheme (cfClassScheme) entity is of one of the main entities in the Semantic Layer. Its internal identifier cfClassSchemId is used for references from within all CERIF link entities. It has a recursive entity cfClassificationScheme_ClassificationScheme (cfClassScheme_ClassScheme) which is formally also a link entity. A classification scheme in CERIF is additionally understandable from the underlying context in which the terms are applied (e.g. Activity Structure in cfProj_Proj; Person Employment Types in cfPers_OrgUnit).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/EducationDomainTerms.xml
+++ b/vocab/xml/EducationDomainTerms.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>b0ca7692-7fda-499f-be40-b44a7bc4f7c7</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Education Domain Terms</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfService_Classification link entity, being used as a vocabulary of educational material, e.g. courses.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Education Domain Terms -->
+      <!-- usage with CERIF: cfSrv_Class -->
+      <cfClassId>e88f9cfd-b786-40cb-9163-4718dbb865ff</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Course</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A course text is a type of study text used as a support for students.</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Education Domain Terms -->
+      <!-- usage with CERIF: cfEvent_Class -->
+      <cfClassId>300592ee-e671-4054-a852-ab37b0d744c1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Course Presentation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is temporal manifestation of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has temporal manifestation</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">A course originating in the Education context is considered a type of service, therefore applicable in the cfSrv_Class link entity. Furthermore, a course presentation is considered an event, hence cfEvent_Class. The series of events linked to a service define the temporal manifestation of the service, which is thus</cfDescr>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF TG meeting in Edinburgh (see meeting report).</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ElectronicAddressTypes.xml
+++ b/vocab/xml/ElectronicAddressTypes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>1227a225-db7a-444d-a74b-3dd4b438b420</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Electronic Address Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfElectronicAddress_Classification link entity, being used as a vocabulary of electronic address types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details; Electronic Address Types -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr; cfEAddr_Class -->
+      <cfClassId>35d43364-2160-4b6c-a487-5019458321e8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Professional Email</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Electronic Address Types -->
+      <!-- usage with CERIF: cfEAddr_Class -->
+      <cfClassId>44651010-00b1-4543-ae6f-b5983b704742</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">MobilePhone</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Electronic Address Types -->
+      <!-- usage with CERIF: cfEAddr_Class -->
+      <cfClassId>abeddcc6-207b-4b9c-9cec-0de22087b728</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Smartphone</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Electronic Address Types -->
+      <!-- usage with CERIF: cfEAddr_Class -->
+      <cfClassId>341b4fcc-9fe4-4760-a9c8-0f36ffa4d614</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Fixedphone</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/EventTypes.xml
+++ b/vocab/xml/EventTypes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>e489092b-82a9-4c24-a357-d94dc49eec9b</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Event Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfEvent_Classification link entity, being thus event types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Activity Types; Output Types; Event Types -->
+      <!-- usage with CERIF: cfProj_Class; cfEvent_Class; Event_Class -->
+      <cfClassId>909ea9bd-e460-497e-8950-9ad306675ae9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity that brings together people to discuss topics around an agreed theme.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Subtypes; Event Types -->
+      <!-- usage with CERIF: cfProj_Class; cfEvent_Class -->
+      <cfClassId>33fd9fc9-48b5-41c5-a2f6-b97c6996e432</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Workshop</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A physical or virtual networking activity bringing people together for a single gathering.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/FunderTypes.xml
+++ b/vocab/xml/FunderTypes.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>7e21f287-2c00-443b-ae61-fd9ed9e71333</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Funder Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The types of funding organisations defined by HESA: http://www.ref.ac.uk/media/ref/content/subguide/01_12a.pdf (page 11)</cfDescr>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>3a48310a-fb4a-4177-bb92-cf1aeb0efebb</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">EU Government Bodies (including EC)</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from all government bodies operating in the EU, which includes the European Commission but excludes bodies in the UK.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>c54a63e9-d59d-4bf9-9b81-23b538de8fd6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">EU Other</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">EU-based non-competitive charities and any other EU income that cannot otherwise be allocated more specifically.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>0e737bcb-2fec-4c40-90f7-f9aefd8dac8f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Other Services</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Income services that cannot otherwise be allocated more specifically.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>dd8df2e3-c481-452f-b9c9-6e426386017f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UK-based Industry Commerce &amp; Public Corporations</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from industrial and commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating in the UK.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>032fcb89-8340-4fe3-a5e4-b1191cf6bc31</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Councils</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">The sources of income from BBSRC, MRC, NERC, EPSRC, ESRC, AHRC, STFC, The Royal Society, British Academy, The Royal Society of Edinburgh</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>874653df-8ced-4ae6-a8ed-449c42f18082</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UK-based Charities</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from all charitable foundations, charitable trusts etc., based in the UK which are registered with the Charities Commission exempt Research Counculs, central government bodies/local authorities, health &amp; hospital authorities. Those organisations recognised as charities by the Office of the Scottish Charity Regulator (OSCR) in Scotland.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>3093abcb-c0d7-4cb7-a5a6-82f40e798811</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UK Central / Local Government Health and Hospital</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from UK central government bodies, UK local authorities and UK health and hospital authorities, except Research Councils and UK public corporations. This should include government departments, and other organisations (including registered charities) financed from central government funds. Research grants and contracts income from non-departmental public bodies (NDPBs), including the British Council, should be included under this column.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>bf682b89-0ce7-4fdc-ac67-35bfd2be436e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">EU-based Charities</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from an EU body with exclusively charitable purposes consistent with the definition set out in the Charities Act 2006 and which exists for the public benefit in a manner which is consistent with the Public Benefit Guidance published by the Charity Commission for England and Wales (http://www.charitycommission.gov.uk/publicbenefit/publicbenefit.asp ).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>abb6de22-ad1b-439a-944f-9e90544a2c0f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Other Overseas</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from industrial and commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating from outside the EU.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>b2a4dd0d-2bbb-4089-8826-99894262e7b3</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">EU-based Industry</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from industrial companies operating in the EU outside of the UK. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a French subsidiary making the award would be coded EU other, where UK is excluded from the EU.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>7c32bcd0-0c34-4103-8d10-a3908b041b06</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">EU Commerce &amp; Public Corporations</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating in the EU outside of the UK. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a French subsidiary making the award would be coded EU other, where UK is excluded from the EU.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>46df9200-e355-45e7-84e7-fdda25dc14ac</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Non-EU-based Industry</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from industrial and commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating outside of the EU. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a US subsidiary making the award would be coded Other overseas.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>b1ec752b-de87-4377-9c28-87b84ac17845</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Non-EU-based Commerce &amp; Public Corporations</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from commercial companies and public corporations (defined as publicly owned trading bodies, usually statutory corporations, with a substantial degree of financial independence) operating outside of the EU. Such income received from a multinational company should be coded depending on the location of the office making the award, e.g. a multinational with a US subsidiary making the award would be coded Other overseas, i.e. from outside the EU.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>92c1c6c0-b3ba-4edf-b34c-bc6ee14bc756</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Non-EU-based Charities</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from a Non-EU body with exclusively charitable purposes consistent with the definition set out in the Charities Act 2006 and which exists for the public benefit in a manner which is consistent with the Public Benefit Guidance published by the Charity Commission for England and Wales (http://www.charitycommission.gov.uk/publicbenefit/publicbenefit.asp). Grants and contracts income from overseas charity bodies operating outside the EU.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>5ca5a3e7-70b8-4f39-a480-b4989f67e7da</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Other Sources</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income not to be allocated more specifically. This should include income from other higher education institutions (HEIs).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>8c6c81e3-6efc-49a6-a7a7-5cd13345d50f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Donations</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants received as a Donation.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>78e3de8c-ee32-4ec8-8cc0-6b5f664e6ca1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Institution-based</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants allocated by the institution.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>62d67cb9-2fc5-4afb-a95f-582d55ed916b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">KTP Grants</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Income from Knowledge Transfer Partnerships (KTPs) apart from any portion in respect of studentships or tuition fees.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>94b8e8e8-5279-4bc2-8b15-b96dc3dc7ff5</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Non-EU Other</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Non-EU-based non-competitive charities and any other Non-EU income that cannot otherwise be allocated more specifically.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>af3b394e-61f3-431d-8a90-f7cb972993e7</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UK-based Government Bodies</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income from all government bodies operating in the UK.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funder Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>ab2e7af8-7043-4533-a60b-9752f28acbdd</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UK Other Sources</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project; HESA</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Grants and contracts income not covered by other types. This should include income from other higher education institutions (HEIs).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_content&amp;task=view&amp;id=1317&amp;Itemid=233</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/FundingSourceDocumentRelations.xml
+++ b/vocab/xml/FundingSourceDocumentRelations.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>c1aef353-5dbb-46a2-86bf-709bb4be3b4d</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Funding Source Document Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfResultPublication_Funding link entity, being thus funding source document, assuming the funding concept in CERIF subsumes funding programme, tender, call, and not the income as such, which would be a financial means and as such in CERIF be a measurement.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Funding Source Document Relations -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>eda2b2d9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funding Programme Document</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is funding programme document of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has funding programme document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The initial funding programme document of a funding programme.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Document Relations -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>eda2b2da-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Call Document</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is call document of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has call document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The initial call document of a call.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Document Relations -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>eda2b2db-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Tender Document</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is tender document of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has tender document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The initial tender document of a tender.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Document Relations -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>eda2b2dc-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Gift Document</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is gift document of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has gift document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The initial gift document of a gift.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/FundingSourceTypes.xml
+++ b/vocab/xml/FundingSourceTypes.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af93b-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Funding Source Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfFund_Classification link entity, being thus Funding source types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Funding Source Types -->
+      <!-- usage with CERIF: cfFund_Class -->
+      <cfClassId>eda2b2e6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funding Programme</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A Funding Programme is the source of financial means to a project, programme, equipment, event or any other structured scientific activity. A Funding Programme is managed by a Funding Organisation.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.eurocris.org/Uploads/Web%20pages/members_meetings/200905_-_Athens__Greece/Funding_Program_Workshop._Introduction_-_Geert_van_Grootel.ppt</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Types -->
+      <!-- usage with CERIF: cfFund_Class -->
+      <cfClassId>eda2b2e7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Call</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">no source found</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Types -->
+      <!-- usage with CERIF: cfFund_Class -->
+      <cfClassId>eda2b2e8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Tender</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">1) An unconditional offer made by one to another to enter into the contract of transaction of goods or services at certain specified cost. Normally government bodies and business groups issues notices for quotes for specified goods or services from other businesses which is known as tender. 2) act of offering money or settlement for any dues or claims.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.legal-explanations.com/definitions/tender.htm</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A call for tenders from a funder addressing a specific requirement resulting in a number of contracts.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Types -->
+      <!-- usage with CERIF: cfFund_Class -->
+      <cfClassId>eda2b2e9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Gift</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A gift or a present is the transfer of something without the expectation of receiving something in return. Although gift-giving might involve an expectation of reciprocity, a gift is meant to be free.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Gift</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Funding Source Types -->
+      <!-- usage with CERIF: cfFund_Class -->
+      <cfClassId>40d72109-28ba-4110-a3e9-23ecca3bb795</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Internal Funding</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Where the source of funding comes from the institution itself (e.g. a university-wide conference-attendance scheme).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/IdentifierServiceRoles.xml
+++ b/vocab/xml/IdentifierServiceRoles.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>5a270628-f593-4ff4-a44a-95660c76e182</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Identifier Service Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfFederatedIdentifier_Service link entity, being thus a vocabulary of roles within the relation of identification service providers, e.g. Issuer.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Organisation Funding Roles; Identifier Service Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Fund; cfFedId_Srv -->
+      <cfClassId>eda2b2e2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Issuer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is issued by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has issued</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">An authority to issue an identifier.</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An issuer is an institution that issues something (securities or publications or currency etc.).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=issuer;</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/IdentifierTypes.xml
+++ b/vocab/xml/IdentifierTypes.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>bccb3266-689d-4740-a039-c96594b4d916</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Identifier Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfFederatedIdentifier_Classification link entity, being thus a vocabulary of current authority identifiers (extensible and meant as a first start).</cfDescr>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>31d222b4-11e0-434b-b5ae-088119c51189</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">DOI</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CRISPool project; RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Digital Object Identifier</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.doi.org/doi_handbook/Glossary.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>56f4fdbc-39a7-42cd-bd35-9d0d8c95f6da</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">PMCID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CRISPool project; RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">PubMed Central ID</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.research.ucla.edu/ora/training/documents/Nov-10/5.pdf</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>008f9358-61db-46e2-8157-beb55e972aa6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">ISI-Number</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CRISPool project; RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">ISI Web Of Knowledge Number</cfDescr>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>fafa2259-304e-4aa4-8419-f84b9cf6f2eb</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">ScopusAffiliationID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CRISPool project; RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Scopus Affiliation Identifier</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.info.sciverse.com/scopus/scopus-in-detail/tools/affiliationidentifier</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>24ddadbc-9b33-40c5-9d25-73b055f0183a</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">ScopusAuthorID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CRISPool project; RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Scopus Author Identifier</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.info.sciverse.com/scopus/scopus-in-detail/tools/authoridentifier</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>716bcc9a-c9dd-4b8b-b4ab-6c140e578ec3</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">ORCID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CRISPool project; RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Open Researcher &amp; Contributor ID</cfDescr>
+      <cfDef cfLangCode="en" cfTrans="o">ORCID is an international, interdisciplinary, open, and not-for-profit organization created for the benefit of all stakeholders, including research institutions, funding organizations, publishers, and researchers to enhance the scientific discovery process and improve collaboration and the efficiency of research funding.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://about.orcid.org/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>872e7b38-e11b-4b0f-b68b-6c6279c92e53</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">INSTID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">HESA Institution Identifier</cfDescr>
+      <cfDef cfLangCode="en" cfTrans="o">The institution identifier of the reporting institution. The institution is identified by two fields, field 2, HESA institution identifier (a four digit number relating to the institution) and field 3, Campus identifier, a single alphanumeric character. The Campus identifier character 'A' will be designated the default for the whole institution.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_collns&amp;task=show_manuals&amp;Itemid=233&amp;r=96011&amp;f=2</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>c0071785-549a-4379-a2af-d9a978ea3a1e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">STAFFID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">HESA Staff Identifier</cfDescr>
+      <cfDef cfLangCode="en" cfTrans="o">The Staff identifier is a unique code allocated to a staff member when they are first entered onto the staff record and, where a member of staff is contracted to work in jobs classified in SOC groups 1,2 or 3, it stays with them for the whole of their career within HE.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/component/option,com_collns/task,show_manuals/Itemid,233/r,08025/f,003/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>68e498fb-c8ee-4a08-a647-b191df5cac39</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">HUSID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">HESA Student Identifier</cfDescr>
+      <cfDef cfLangCode="en" cfTrans="o">The Student identifier is to be unique to each student. It is intended that the identifier is to be transferred with the student to each institution of higher education he/she may attend. The medium term objective is that the use of this number will allow the accurate tracking of students throughout their life within the sector for which HESA collects data.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.hesa.ac.uk/index.php?option=com_collns&amp;Itemid=233&amp;task=show_manuals&amp;r=96011&amp;f=004</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>b4a7caf0-5257-411e-accc-d1ee70d2f701</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">ResearcherID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The ResearcherID by Thomson Reuters.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.researcherid.com/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>39436e26-6d68-4b5a-8ba1-d002a979fdea</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UKPRN</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">UK Provider Reference Number</cfDescr>
+      <cfDef cfLangCode="en" cfTrans="o">The UK Register of Learning Providers is a 'one-stop' portal to be used by government departments, agencies, learners, and employers to share key information about learning providers. The UKRLP allows providers to update their information in one place and share this across agencies such as the Skills Funding Agency, the Higher Education Statistics Agency (HESA), the Higher Education Funding Council for England (HEFCE) and UCAS. Since provider registration opened on 1st August 2005, the UKRLP has grown to over 25,000 providers. Each of these has been verified against a recognised external source and has been allocated a UK Provider Reference Number (UKPRN). This is the unique identifier used to share information with the UKRLP partner agencies.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ukrlp.co.uk/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>f2dc329b-f47e-4876-9ceb-b190c19aca98</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">URI</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Uniform Resource Identifier</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Uniform_resource_identifier</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>7f65458e-00de-4eaf-8109-01e517790a2c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">URL</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Uniform Resource Locator</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Uniform_resource_locator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>ba36c17a-c056-4d7b-aa26-b62bb04cdfc6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">HR-ID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">The ID as recorded in the HR system.</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>b52eef12-0dca-4496-ae86-9389de0437f6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Project-MM-ID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">The ID as recorded in the project management system</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>c02711cd-7cfb-4b20-ba2e-15c8c1179a05</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Repository-ID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">The ID as recorded in the repository.</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>7916dbe8-9264-4810-92df-7c21ab733338</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Finance-ID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">The ID as recorded in the finance system.</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>708d9118-c4dd-4813-8ff7-b43bf0a493b0</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">CRIS-ID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">The ID as recorded in the CRIS.</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>e093fb4c-4d5e-4602-8878-22e7dc360c36</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">DNR</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Diari-Number in Sweden.</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>c7e9afa5-02ce-4222-88f8-b717051fed39</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">ISNI</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">International Standard Name Identifier</cfDescr>
+      <cfDef cfLangCode="en" cfTrans="o">The International Standard Name Identifier (ISNI) is an ISO Standard (ISO 27729) whose scope is the identification of Public Identities of parties: that is, the identities used publicly by parties involved throughout the media content industries in the creation, production, management, and content distribution chains. The ISNI system uniquely identifies Public Identities across multiple fields of creative activity. The ISNI provides a tool for disambiguating Public Identities that might otherwise be confused. ISNI is not intended to provide direct access to comprehensive information about a Public Identity but can provide links to other systems where such information is held.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.isni.org/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>e0d3ce71-2d85-4b6b-8103-636276d31c1d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">UUID</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">Unique Universal Identifier</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Universally_unique_identifier</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>baaa59e1-745b-46e3-b068-aaa3dae9eef9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Handle</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">The Handle System provides efficient, extensible, and secure resolution services for unique and persistent identifiers of digital objects, and is a component of CNRI's Digital Object Architecture. Digital Object Architecture provides a means of managing digital information in a network environment. A digital object has a machine and platform independent structure that allows it to be identified, accessed and protected, as appropriate. A digital object may incorporate not only informational elements, i.e., a digitized version of a paper, movie or sound recording, but also the unique identifier of the digital object and other metadata about the digital object. The metadata may include restrictions on access to digital objects, notices of ownership, and identifiers for licensing agreements, if appropriate.</cfDescr>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.handle.net/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Identifier Types -->
+      <!-- usage with CERIF: cfFedId_Class -->
+      <cfClassId>634197d9-3a2e-4df7-b982-18b41a7e6f24</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">VAT Identification Number</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A value added tax identification number or VAT identification number (VATIN) is an identifier used in many countries, including the countries of the European Union, for value added tax purposes.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/VAT_identification_number</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterEquipmentRelations.xml
+++ b/vocab/xml/InterEquipmentRelations.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>623d2471-8d16-40c9-915a-df496da086be</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Equipment Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfEquipment_Equipment link entity, being thus an inter-equipment relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterEventRelations.xml
+++ b/vocab/xml/InterEventRelations.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>ac90d633-8ad6-4c23-b45a-cc4f91309843</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Event Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfEvent_Event link entity, being thus an inter-event relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bca-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Successor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is successor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has successor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A successor is someone who, or something which succeeds or comes after.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Successor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bcb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Predecessor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is predecessor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has predecessor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Something that precedes and indicates the approach of something or someone.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterFacilityRelations.xml
+++ b/vocab/xml/InterFacilityRelations.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>da0e5a01-c73e-4489-8cf7-917e9efcdad4</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Facility Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfFacility_Facility link entity, being thus an inter-facility relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterOrganisationalStructure.xml
+++ b/vocab/xml/InterOrganisationalStructure.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>cf7772d0-3477-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Organisational Structure</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_OrganisationUnit link entity, being thus an inter-organisational structure.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit -->
+      <cfClassId>cb3e0010-1cd7-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Member</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is member of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has member</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the member role happens e.g. within the relationships person-organisation, person-project; organisation-organisation, that is, the classification term (cfTerm) "Member" identified by its cfClassificationIdentifier (a uuid), and reused with e.g. the cfPerson_OrganisationUnit; cfProject_Person; cfOrganisationUnit_OrganisationUnit relationships. A person can be a member of multiple organisations. An organization can be a member of another organization, or a state that belongs to a group of nations.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A member is anything that belongs to a set or class.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=member</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Person Funding Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund -->
+      <cfClassId>79a2e340-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Manager</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is manager of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has manager</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A manager is someone who controls resources and expenditures.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit -->
+      <cfClassId>c9a24a22-d3f2-4b15-aa06-cb512b2f1341</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Auditor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is auditor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has auditor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, auditor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Auditor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An official whose job it is to carefully check the accuracy of business records. An auditor can be either an independent auditor unaffiliated with the company being audited or a captive auditor, and some are elected public officials. The term is sometimes synonymous with "comptroller." Auditors are used to ensure that organizations are maintaining accurate and honest financial records and statements.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.investopedia.com/terms/a/auditor.asp#ixzz238Yb6H7h</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>abf21190-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation contracted to undertake a specific bounded (time and specification) subset of an activity. Normally such an organisation would not retain an interest in any IP generated from the activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Person Employment Types; Person Project Engagements -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfPers_OrgUnit; cfPers_Proj -->
+      <cfClassId>eda28bc5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Supporter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is supporter of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has supporter</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">The person not directly involved in the activity but contributing to maintaining the infrastructure.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A supporter is someone who supports or champions something.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=supporter</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event; cfResPubl_Fund; cfResPat_Fund; cfResProd_Fund; cfEvent_Fund; cfFacil_Fund; cfEquip_Fund; cfSrv_Fund -->
+      <cfClassId>eda28bc0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is funder of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has funder</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that provides funding towards the cost of an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.businessdictionary.com/definition/funder.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Mereotopological Structure -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit -->
+      <cfClassId>eda28bc3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Acquisition</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is acquired by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has acquired</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An acquisition is the act of contracting or assuming or acquiring possession of something</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=acquisition</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Mereotopological Structure -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit -->
+      <cfClassId>eda28bc4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Takeover</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is taken over by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has taken over</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A takeover is a change by sale or merger in the controlling interest of a corporation.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=takeover</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>eda28bc6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Stakeholder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is stakeholde of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has stakeholder</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A corporate stakeholder is a party that can affect or be affected by the actions of the business as a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Stakeholder_(corporate)</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit -->
+      <cfClassId>eda28bc7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Merger</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is merger of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has merger</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A merger is a voluntary amalgamation of two firms on roughly equal terms into one new legal entity. Mergers are effected by exchange of the pre-merger stock (shares) for the stock of the new firm. Owners of each pre-merger firm continue as owners, and the resources of the merging entities are pooled for the benefit of the new entity. If the merged entities were competitors, the merger is called horizontal integration, if they were supplier or customer of one another, it is called vertical integration.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.businessdictionary.com/definition/merger.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bca-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Successor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is successor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has successor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A successor is someone who, or something which succeeds or comes after.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Successor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bcb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Predecessor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is predecessor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has predecessor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Something that precedes and indicates the approach of something or someone.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Project Outcome Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>eda28bcc-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Spin-Off</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is spin-off from</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has spin-off</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A spin-out, also known as a spin-off or a starburst, refers to a type of corporate action where a company "splits off" sections of itself as a separate business.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Corporate_spin-off</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Structure; Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfProj_Proj; cfOrgUnit_OrgUnit -->
+      <cfClassId>eda2b2d7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Cooperation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in cooperation with</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has cooperation</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A cooperation is the collaborative work on a common enterprise or project.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterOutputRelations.xml
+++ b/vocab/xml/InterOutputRelations.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>a7e0dc90-1be4-4fd9-9ff7-bdfb8a95a1eb</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Output Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in e.g. a cfResultPublication_ResultPatent; cfResultPublication_ResultProduct link entity, being thus an inter-output relations. The type of relationships between two outputs (e.g publication and data).</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Activity Structure; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfProj_Proj; cfProj_Equip; cfProj_Facil; cfProj_Srv; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResPubl; cfResProd_ResProd; cfResPat_ResPat; -->
+      <cfClassId>eda28bc9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Built on</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is built on</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has built</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Built on - is a form of succession - informally expressed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterPatentRelations.xml
+++ b/vocab/xml/InterPatentRelations.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>50772538-d92f-4048-ae76-93e1659afc8b</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Patent Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfResultPatent_ResultPatent link entity, being thus an inter-patent relation.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bca-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Successor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is successor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has successor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A successor is someone who, or something which succeeds or comes after.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Successor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bcb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Predecessor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is predecessor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has predecessor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Something that precedes and indicates the approach of something or someone.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterProductRelations.xml
+++ b/vocab/xml/InterProductRelations.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>f5c75446-de28-4c4b-8739-8f6223a09e88</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Product Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfResultProduct_ResultProduct link entity, being thus an inter-product relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bca-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Successor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is successor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has successor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A successor is someone who, or something which succeeds or comes after.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Successor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bcb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Predecessor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is predecessor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has predecessor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Something that precedes and indicates the approach of something or someone.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterPublicationRelations.xml
+++ b/vocab/xml/InterPublicationRelations.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af932-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Publication Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfResultPublication_ResultPublication link entity, being thus an inter-publication relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Publication Relations; Mereotopological Structure -->
+      <!-- usage with CERIF: cfResPubl_ResPubl -->
+      <cfClassId>eda28bc8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Derived from</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is derived from</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has derivation</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A derivation is the source or origin from which something derives.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=derivation</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bca-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Successor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is successor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has successor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A successor is someone who, or something which succeeds or comes after.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Successor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event -->
+      <cfClassId>eda28bcb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Predecessor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is predecessor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has predecessor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Something that precedes and indicates the approach of something or someone.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=predecessor</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/InterServiceRelations.xml
+++ b/vocab/xml/InterServiceRelations.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>39f413d8-e5ee-409a-95f1-d204b78508b9</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Inter-Service Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfService_Service link entity, being thus an inter-service relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv -->
+      <cfClassId>eda28bc1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Part</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is part of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has part</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A part is a portion, division, piece, or segment of a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/part</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Activity Structure; Inter-Organisational Structure; Activity Structure; Inter-Publication Relations; Inter-Patent Relations; Inter-Product Relations; Inter-Event Relations; Inter-Facility Relations; Inter-Equipment Relations; Inter-Service Relations; Activity Output Contributions; Activity Output Contributions; Activity Output Contributions; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_Proj; cfFund_Fund; cfResPubl_ResPubl; cfResPat_ResPat; cfResProd_ResProd; cfEvent_Event; cfFacil_Facil; cfEquip_Equip; cfSrv_Srv; cfResProd_cfResProd; cfResPat_cfResPat; cfFacil_Equip; cfEquip_Srv; cfFacil_Srv; cfEvent_Srv; cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResProd; cfResPubl_ResPat; -->
+      <cfClassId>eda28bc2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Relation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is related to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has relation</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A relationship.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An abstraction belonging to or characteristic of two entities or parts together.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Relation</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/MediaRelations.xml
+++ b/vocab/xml/MediaRelations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>40d45f50-db4b-449c-b4f6-ae202b220e5a</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Media Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in link entities relating to medium, such as cfOrgUnit_Medium; cfProj_Medium ... (in the function of e.g. Logo).</cfDescr>
+    <cfClass>
+      <!-- class schemes: Media Relations -->
+      <!-- usage with CERIF: cfOrgUnit_Medium; cResProd_Medium; cfProj_Medium -->
+      <cfClassId>9931ac47-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Logo</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The logo representing an entity, such as organisation, product, project.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/MereotopologicalStructure.xml
+++ b/vocab/xml/MereotopologicalStructure.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+	<cfClassScheme>
+		<cfClassSchemeId>065bd11e-0f80-4a5e-a695-54bed2e255a5</cfClassSchemeId>
+		<cfName cfLangCode="en" cfTrans="o">Mereotopological Structure</cfName>
+		<cfDescr cfLangCode="en" cfTrans="o">This scheme implies the CERIF vocabulary terms applicable with intra-entity sturctures - such as Part in e.g. link entities such as cfOrganisationUnit_OrganisationUnit; cfProject_Project.</cfDescr>
+		<cfClass>
+			<!-- class schemes: Inter-Organisational Structure; Mereotopological Structure -->
+			<!-- usage with CERIF: cfOrgUnit_OrgUnit -->
+			<cfClassId>eda28bc3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Acquisition</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+			<cfRoleExpr cfLangCode="en" cfTrans="o">is acquired by</cfRoleExpr>
+			<cfRoleExprOpp cfLangCode="en" cfTrans="o">has acquired</cfRoleExprOpp>
+			<cfDef cfLangCode="en" cfTrans="o">An acquisition is the act of contracting or assuming or acquiring possession of something</cfDef>
+			<cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=acquisition</cfDefSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Inter-Organisational Structure; Mereotopological Structure -->
+			<!-- usage with CERIF: cfOrgUnit_OrgUnit -->
+			<cfClassId>eda28bc4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Takeover</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+			<cfRoleExpr cfLangCode="en" cfTrans="o">is taken over by</cfRoleExpr>
+			<cfRoleExprOpp cfLangCode="en" cfTrans="o">has taken over</cfRoleExprOpp>
+			<cfDef cfLangCode="en" cfTrans="o">A takeover is a change by sale or merger in the controlling interest of a corporation.</cfDef>
+			<cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=takeover</cfDefSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Inter-Publication Relations; Mereotopological Structure -->
+			<!-- usage with CERIF: cfResPubl_ResPubl -->
+			<cfClassId>eda28bc8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Derived from</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+			<cfRoleExpr cfLangCode="en" cfTrans="o">is derived from</cfRoleExpr>
+			<cfRoleExprOpp cfLangCode="en" cfTrans="o">has derivation</cfRoleExprOpp>
+			<cfDef cfLangCode="en" cfTrans="o">A derivation is the source or origin from which something derives.</cfDef>
+			<cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=derivation</cfDefSrc>
+		</cfClass>
+	</cfClassScheme>
+	<head xmlns=""/>
+</CERIF>

--- a/vocab/xml/OpenScienceCosts.xml
+++ b/vocab/xml/OpenScienceCosts.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>e87469e5-d6bd-458c-b7ef-90e314749c51</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Open Science Costs</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The type of cost allocated to an output in order to make it Open Access or Open Dataset.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Open Science Costs -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>98072417-c98b-46dc-99aa-364bb672cd63</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Gold Open Access</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The cost charged by a publisher to make an individual output freely available.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Open Science Costs -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>7cfe736a-73bb-4324-b3dd-34228e5dbe7d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Green Open Access</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The cost of depositing a version of the publication for free public access in a CRIS/institutional repository. Normally this cost will be zero.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Open Science Costs -->
+      <!-- usage with CERIF: cfResPubl_Fund -->
+      <cfClassId>59c67182-270e-4ade-8edb-9cdf16d2e1b1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Data Storage</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The cost of depositing a version of the research data for free public access in a CRIS/institutional repository. The cost may not be zero.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationContactDetails.xml
+++ b/vocab/xml/OrganisationContactDetails.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>fee53e30-de3a-421b-80e0-9b3fe3a3c170</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Contact Details</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">An organisation's electronic and postal contact coordinates. This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_ElectroniAddress or cfOrganisationUnit_PostAddress link entity, being thus organisation contact details.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac41-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Fax</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac42-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Email</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details; Electronic Address Types -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr; cfEAddr_Class -->
+      <cfClassId>35d43364-2160-4b6c-a487-5019458321e8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Professional Email</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>20476135-bc75-40b4-b5f0-f05543e919c6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Skype</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>95bff29c-338f-4790-80ac-c39ec3bc72f4</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Twitter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>beb680a9-4504-417f-b444-65ff289c5952</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Facebook</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>48ed3997-8f3b-41bd-94c5-ba37df71c263</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">LinkedIn</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac44-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Phone</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac45-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Public Access</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac46-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Corporate Access</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Contact Details -->
+      <!-- usage with CERIF: cfOrgUnit_PAddr -->
+      <cfClassId>3e480ccf-15cd-4e73-bdcc-d0d3c73a405c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Organisation Legal Postal Address</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">Conference Abstracts</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">The address to which legal notices may be served.</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Contact Details -->
+      <!-- usage with CERIF: cfOrgUnit_PAddr -->
+      <cfClassId>e103718b-c1b3-4cfd-ae53-d4b5c1d1fcae</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Organisation Financial Postal Address</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">Conference Posters</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">The address to which financial queries should be sent</cfDef>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationFundingRoles.xml
+++ b/vocab/xml/OrganisationFundingRoles.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af937-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Funding Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfOrgUnit_Funding link entity, being thus organisation funding roles.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Organisation Roles; Person Project Engagements; Organisation Funding Roles -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_ResPubl; cfPers_ResPat; cfPers_ResProd; cfPers_Event; cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund -->
+      <cfClassId>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contributor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CIA project; RMAS Project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contributor to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contributor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contact</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contact of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contact</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">The person to be contacted in a particular circumstance (e.g. finance).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">In CERIF terms, contact is a role in e.g. the person-project, organisation-funding, ... relationship; that is, the classification term (cfTerm) "Contact" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contact is a communicative interaction.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contact</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Output Contributions -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfOrgUnit_Fund; cfPers_Fund; cfPers_ResPat -->
+      <cfClassId>33551370-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Applicant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is applicant of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has applicant</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An applicant is an organisation that submits a grant application on behalf of a consortium, partnership or network of participating organisations; the applicant represents and acts on behalf of the group of participating organisation in its relations with the Agency; if the grant application is selected, the Applicant will become the main beneficiary (see Beneficiary definition below) and will sign the grant agreement on behalf of the participating organisations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://eacea.ec.europa.eu/erasmus_mundus/tools/glossary_en.php</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An applicant is also called proposer.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Funding Roles; Identifier Service Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Fund; cfFedId_Srv -->
+      <cfClassId>eda2b2e2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Issuer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is issued by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has issued</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">An authority to issue an identifier.</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An issuer is an institution that issues something (securities or publications or currency etc.).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=issuer;</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Funding Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Fund; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>eda2b2e3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Responsible</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is responsible for</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has responsible</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A responsible is the agent or cause; worthy of or requiring responsibility or trust; or held accountable.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=responsible;</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Funding Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Fund -->
+      <cfClassId>eda2b2e4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Financier</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is financier for</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has financier</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Financier (pronounced /fɪnənˈsɪər/, French: [finɑ̃ˈsje]) is a term for a person who handles typically large sums of money, usually involving money lending, financing projects, large-scale investing, or large-scale money management.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Financier</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationMeasurementRelations.xml
+++ b/vocab/xml/OrganisationMeasurementRelations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>aef32e66-d31a-40db-bbd9-d1df96522987</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Measurement Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable with the cfOrganisationUnit_Measurement entity, being thus organisation related measurements, such as e.g. cost center.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Organisation Measurement Relations -->
+      <!-- usage with CERIF: cfOrgUnit_Meas -->
+      <cfClassId>eda2b2e5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Cost Center</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is cost center of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has cost center</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">In business, a cost centre is a division that adds to the cost of an organization, but only indirectly adds to its profit. Typical examples include research and development, marketing and customer service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Cost_centre_%28business%29</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationOutputContributions.xml
+++ b/vocab/xml/OrganisationOutputContributions.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6b2b7d26-3491-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Output Contributions</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_ResultPublication link entity, being thus an organisation's output contribution.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Person Output Contributions; Organisation Project Engagements; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfPers_ResPubl; cfProj_OrgUnit; cfOrgUnit_ResPubl -->
+      <cfClassId>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reviewer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reviewer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reviewer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A reviewer is someone who reads manuscripts and judges their suitability for publication.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl -->
+      <cfClassId>49815870-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Author</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is author of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has author</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An author is the person or corporate entity responsible for producing a written work (essay, monograph, novel, play, poem, screenplay, short story, etc.) whose name is printed on the title page of a book or given elsewhere in or on a manuscript or other item and in whose name the work is copyrighted. A work may have two or more joint authors. In library cataloging, the term is used in its broadest sense to include editor, compiler, composer, creator, etc</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_e.cfm#author</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Contributions; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl; cfProj_OrgUnit -->
+      <cfClassId>7ef398b3-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Commissioner</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is commissioner of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has commissioner</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">The organisation that wishes the work to be undertaken (this might be the lead funder in a consortium funded project).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A government administrator, a member of a commission.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_t.cfm#commissioner</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Output Contributions; Organisation Output Contributions; Organisation Output Contributions; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>eda2b2d5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reviewer Institution</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reviewer institution of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reviewer institution</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A reviewer institution is an organization founded and united for a specific purpose where the reviewer has a relationship.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfOrgUnit_Facil; cfOrgUnit_Equip; cfOrgUnit_Srv; cfOrgUnit_Event -->
+      <cfClassId>eda2d9ff-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Host</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is host of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has host</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationOutputRoles.xml
+++ b/vocab/xml/OrganisationOutputRoles.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>877161b4-00d2-42c8-a368-aaa35262f3a8</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Output Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_ResultPublication link entity, being used as a vocabulary of organisation output roles - different from organisation output contribution.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>7ef398b2-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Publisher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is publisher of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has publisher</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person or corporate entity that prepares and issues printed materials for public sale or distribution, normally on the basis of a legal contract in which the publisher is granted certain exclusive rights in exchange for assuming the financial risk of publication and agreeing to compensate the author, usually with a share of the profits.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_t.cfm#publisher</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event; cfResPubl_Fund; cfResPat_Fund; cfResProd_Fund; cfEvent_Fund; cfFacil_Fund; cfEquip_Fund; cfSrv_Fund -->
+      <cfClassId>eda28bc0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is funder of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has funder</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that provides funding towards the cost of an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.businessdictionary.com/definition/funder.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>eda2b2d0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">IPR Claim</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">claims ipr of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has ipr claim by</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">1. The rights of creative workers in literary, artistic, industrial and scientific fields which can be protected either by copyright or trademarks, patents, etc. 2. Tangible products of the human mind and intelligence entitled to the legal status of personal property, especially works protected by copyright, inventions that have been patented, and registered trademarks. An idea is considered the intellectual property of its creator only after it has been recorded or made manifest in specific form.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.newcastle.edu.au/service/library/tutorials/infoskills/glossary.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>eda2b2d2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Curator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is curator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has curator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person responsible for the development, care, organization, and supervision of a museum, gallery, or other exhibit space and all the objects stored or displayed in it, a role requiring considerable knowledge and experience when items are selected on the basis of artistic merit or connoisseurship. Also, a person in charge of a special collection, trained to assist users in locating and interpreting its holdings.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/search.cfm</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>eda2b2d3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Author Institution</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is author institution of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has author institution</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An author institution is an organization founded and united for a specific purpose where the author has a relationship.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>eda2b2d4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Publisher Institution</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is publisher institution of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has publisher institution</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A publisher institution is an organization founded and united for a specific purpose where the publisher has a relationship.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>eda2b2d6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">External Organisation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is external organisation of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has external organisation</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An external organisation an organization founded and united for a specific purpose that is happening or arising or located outside or beyond some limits or especially surface.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=External; http://wordnetweb.princeton.edu/perl/webwn?s=institution</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationProjectEngagements.xml
+++ b/vocab/xml/OrganisationProjectEngagements.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6b2b7d25-3491-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Project Engagements</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfProject_OrganisationUnit link entity - being thus an organisation's project engagement.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Person Output Contributions; Organisation Project Engagements; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfPers_ResPubl; cfProj_OrgUnit; cfOrgUnit_ResPubl -->
+      <cfClassId>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reviewer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reviewer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reviewer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A reviewer is someone who reads manuscripts and judges their suitability for publication.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>abf21190-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation contracted to undertake a specific bounded (time and specification) subset of an activity. Normally such an organisation would not retain an interest in any IP generated from the activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfProj_OrgUnit -->
+      <cfClassId>b272a660-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Subcontractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is subcontractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has subcontractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A subcontractor is someone who enters into a subcontract with the primary contractor.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=subcontractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit -->
+      <cfClassId>c31d3380-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Coordinator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is coordinator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has coordinator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, coordinator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Coordinator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The lead partner in a consortium.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A coordinator is someone whose task is to see that work goes harmoniously.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=coordinator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Person Event Involvements -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfPers_Event -->
+      <cfClassId>ddc3dd10-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Participant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is participant in</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has participant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, participant is a role e.g. in the person-project relationship; that is, the classification term (cfTerm) "Participant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A participant is someone who takes part in an activity</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=participant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Output Contributions -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfOrgUnit_Fund; cfPers_Fund; cfPers_ResPat -->
+      <cfClassId>33551370-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Applicant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is applicant of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has applicant</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An applicant is an organisation that submits a grant application on behalf of a consortium, partnership or network of participating organisations; the applicant represents and acts on behalf of the group of participating organisation in its relations with the Agency; if the grant application is selected, the Applicant will become the main beneficiary (see Beneficiary definition below) and will sign the grant agreement on behalf of the participating organisations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://eacea.ec.europa.eu/erasmus_mundus/tools/glossary_en.php</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An applicant is also called proposer.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Contributions; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl; cfProj_OrgUnit -->
+      <cfClassId>7ef398b3-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Commissioner</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is commissioner of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has commissioner</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">The organisation that wishes the work to be undertaken (this might be the lead funder in a consortium funded project).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A government administrator, a member of a commission.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_t.cfm#commissioner</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event; cfResPubl_Fund; cfResPat_Fund; cfResProd_Fund; cfEvent_Fund; cfFacil_Fund; cfEquip_Fund; cfSrv_Fund -->
+      <cfClassId>eda28bc0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is funder of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has funder</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that provides funding towards the cost of an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.businessdictionary.com/definition/funder.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Project Engagements -->
+      <!-- usage with CERIF: cfProj_OrgUnit -->
+      <cfClassId>69948e23-7c53-4437-a33e-17c051b9281b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Inkind-Contributor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is inkind-contributor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has inkind-contributor</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that provides a non-monetary contribution towards an activity (e.g. staff time, use of facilities).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An organisation that provides a non-monetary contribution towards an activity (e.g. staff time, use of facilities).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS project</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Project Engagements -->
+      <!-- usage with CERIF: cfProj_OrgUnit -->
+      <cfClassId>c77f9885-b80d-466a-9097-9768720c0fe1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Partner</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is partner in</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has partner</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation working in collaboration as part of a consortium to undertake an activity. Normally retaining an interest in any IP generated.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An organisation working in collaboration as part of a consortium to undertake an activity. Normally retaining an interest in any IP generated.</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Project Engagements -->
+      <!-- usage with CERIF: cfProj_OrgUnit -->
+      <cfClassId>f27bedda-f04c-4d32-a026-d4955bb65227</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Sponsor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is sponsor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has sponsor</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that undertakes to ensure the research governance of the activity (used in the UK especially in the Health and Social Services domain).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An organisation that undertakes to ensure the research governance of the activity (used in the UK especially in the Health and Social Services domain).</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>eda28bc6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Stakeholder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is stakeholde of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has stakeholder</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A corporate stakeholder is a party that can affect or be affected by the actions of the business as a whole.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Stakeholder_(corporate)</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationResearchInfrastructureRoles.xml
+++ b/vocab/xml/OrganisationResearchInfrastructureRoles.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af93e-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Research Infrastructure Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_Equipment; cfOrganisationUnit_Service, cfOrganisationUnit_Facility link entities, being thus organisation infrastructure roles.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Facil; cfOrgUnit_Equip; cfOrgUnit_Srv -->
+      <cfClassId>eda2d9fe-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Owner</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is owner of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has owner</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfOrgUnit_Facil; cfOrgUnit_Equip; cfOrgUnit_Srv; cfOrgUnit_Event -->
+      <cfClassId>eda2d9ff-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Host</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is host of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has host</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Facil; cfOrgUnit_Equip; cfOrgUnit_Srv; cfProj_Facil; cfProj_Equip; cfProj_Srv; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>eda2da00-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">User</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is user of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has user</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">(eg. the Research Organisation)</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OrganisationTypes.xml
+++ b/vocab/xml/OrganisationTypes.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af939-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Organisation Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfOrganisationUnit_Classification link entity, being thus organisation types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2ec-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Academic Institute</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">An academic institution is an educational institution dedicated to education and research, which grants academic degrees.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Academic_institution</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2ed-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">University</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A university is an institution of higher education and research, which grants academic degrees in a variety of subjects. A university is a corporation that provides both undergraduate education and postgraduate education.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/University</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2ee-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">University College</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">The term "university college" is used in a number of countries to denote college institutions that provide tertiary education but do not have full or independent university status. A university college is often part of a larger university. The precise usage varies from country to country.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/University_college</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2ef-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Institute</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS;</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A research institute is an establishment endowed for doing research. Research institutes may specialize in basic research or may be oriented to applied research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Research_institute</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2f0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Strategic Research Insitute</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A strategic research institute's core mission is to provide analyses that respond to the needs of decision-makers.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2f1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Company</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A company is a form of business organization. In the United States, a company is a corporation—or, less commonly, an association, partnership, or union—that carries on an industrial enterprise." Generally, a company may be a "corporation, partnership, association, joint-stock company, trust, fund, or organized group of persons, whether incorporated or not, and (in an official capacity) any receiver, trustee in bankruptcy, or similar official, or liquidating agent, for any of the foregoing." In English law, and therefore in the Commonwealth realms, a company is a form of body corporate or corporation, generally registered under the Companies Acts or similar legislation. It does not include a partnership or any other unincorporated group of persons.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Company</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2f2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">SME</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Small and medium enterprises (also SMEs, small and medium businesses, SMBs, and variations thereof) are companies whose headcount or turnover falls below certain limits. EU Member States traditionally have their own definition of what constitutes an SME, for example the traditional definition in Germany had a limit of 250 employees, while, for example, in Belgium it could have been 100. But now the EU has started to standardize the concept. Its current definition categorizes companies with fewer than 10 employees as "micro", those with fewer than 50 employees as "small", and those with fewer than 250 as "medium".</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Small_and_medium_enterprises; http://ec.europa.eu/enterprise/policies/sme/facts-figures-analysis/sme-definition/index_en.htm</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2f3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Government</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A government is the organization, or agency through which a political unit exercises its authority, controls and administers public policy, and directs and controls the actions of its members or subjects.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Government</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2f4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Higher Education</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Higher education or post-secondary education refers to a level of education that is provided at academies, universities, colleges, seminaries, institutes of technology, and certain other collegiate- level institutions, such as vocational schools, trade schools, and career colleges, that award academic degrees or professional certifications.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Higher_education</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>eda2b2f5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Private non-profit</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">An organization that is incorporated under state law and whose purpose is not to make profit, but rather to further a charitable, civic, scientific, or other lawful purpose.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>13d1fa53-18f0-4bf2-88ca-2d2df474f404</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Intergovernmental</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">VOA3R project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">An example of intergovernmental organisation is FAO (Food and Agriculture Organization)</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/List_of_intergovernmental_organizations</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An intergovernmental organization, sometimes rendered as an international governmental organization and both abbreviated as IGO, is an organization composed primarily of sovereign states (referred to as member states), or of other intergovernmental organizations. Intergovernmental organizations are often called international organizations, although that term may also include international nongovernmental organization such as international non-profit organizations or multinational corporations.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Intergovernmental_organization</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>ecaac6d5-b281-4f0a-a6fa-2c155aa51002</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Charity</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A charitable organization is a type of non-profit organization (NPO). It differs from other types of NPOs in that it centers on philanthropic goals (e.g. charitable, educational, religious, or other activities serving the public interest or common good). The legal definition of charitable organization (and of Charity) varies according to the country and in some instances the region of the country in which the charitable organization operates. The regulation, tax treatment, and the way in which charity law affects charitable organizations also varies.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Charitable_organization</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Types -->
+      <!-- usage with CERIF: cfOrgUnit_Class -->
+      <cfClassId>1d9ffa49-8af2-4844-a228-5498846b8da2</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">National Health Service</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Hospitals, trusts and other bodies receiving funding from central governement through the national insurance scheme.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OutputFundingRoles.xml
+++ b/vocab/xml/OutputFundingRoles.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af933-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Output Funding Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfResulsPublication_Funding link entity, being thus publication funding roles and e.g. a reference to the funding programe, because the funding concept in CERIF subsumes funding programme, tender, call, and not the income as such, which would be a financial means and as such in CERIF be a measurement.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event; cfResPubl_Fund; cfResPat_Fund; cfResProd_Fund; cfEvent_Fund; cfFacil_Fund; cfEquip_Fund; cfSrv_Fund -->
+      <cfClassId>eda28bc0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is funder of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has funder</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that provides funding towards the cost of an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.businessdictionary.com/definition/funder.html</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OutputQualityLevels.xml
+++ b/vocab/xml/OutputQualityLevels.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>1332d166-4c65-481b-adde-aac0bdc475a3</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Output Quality Levels</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">If a quality level has been assigned to an output, then this is the assessment of the level of quality on the REF scale (http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/)</cfDescr>
+    <cfClass>
+      <!-- class schemes: Output Quality Levels -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>19258084-7068-4be1-8cfd-171952060f0c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Pending Grading</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An assessment has yet to be made of the quality level of the output.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Quality Levels -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>f9237eb5-a5c9-433f-887d-e2eac703bc18</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">4-Star</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">REF 2014; RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Quality that is world-leading in terms of originality, significance and rigour.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Quality Levels -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>9e93db57-3349-4bb9-bfba-9481302b4784</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">3-Star</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">REF 2014; RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Quality that is internationally excellent in terms of originality, significance and rigour but which falls short of the highest standards of excellence.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Quality Levels -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>7f1998ce-ddfa-4ece-af02-2eed9a48c8d2</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">2-Star</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">REF 2014; RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Quality that is recognised internationally in terms of originality, significance and rigour.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Quality Levels -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>89644214-e41f-4c30-befb-ab5d9443c08b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">1-Star</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">REF 2014; RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Quality that is recognised nationally in terms of originality, significance and rigour.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Quality Levels -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>7ea05f8e-bd27-4f33-bfa4-54dfb3e6f905</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Unclassified</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">REF 2014; RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Quality that falls below the standard of nationally recognised work. Or work which does not meet the published definition of research for the purposes of this assessment.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/panels/assessmentcriteriaandleveldefinitions/</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OutputResearchInfrastructureRelations.xml
+++ b/vocab/xml/OutputResearchInfrastructureRelations.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6df0658e-34bd-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Output Research Infrastructure Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfResultPublication_Equipment; cfResultPublication_Service, cfResultPublication_Facility link entities, being thus output infrastructure relationss.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Output Research Infrastructure Relations; Output Research Infrastructure Relations; Output Research Infrastructure Relations -->
+      <!-- usage with CERIF: cfProj_Srv; cfProj_Equip; cfProj_Facil; cfResPat_Facil; cfResPat_Equip; cfResPat_Srv; cfResProd_Facil; cfResProd_Equip; cfResProd_Srv -->
+      <cfClassId>eda2da03-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Development</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is developed by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has developed</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/OutputTypes.xml
+++ b/vocab/xml/OutputTypes.xml
@@ -1,0 +1,847 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af938-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Output Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfResultPublication_Classification, cfResultPatent_Classification, cfResultProduct_Classification, cfEvent_Class link entities, being thus output types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Activity Types; Output Types; Event Types -->
+      <!-- usage with CERIF: cfProj_Class; cfEvent_Class; Event_Class -->
+      <cfClassId>909ea9bd-e460-497e-8950-9ad306675ae9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project, CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An activity that brings together people to discuss topics around an agreed theme.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2b2f6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Book</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A book is a collection of leaves of paper, parchment, vellum, cloth, or other material (written, printed, or blank) fastened together along one edge, with or without a protective case or cover.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_B.cfm#book</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2b2f7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Book Review</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A book review is an evaluative account of a recent book, usually written and signed by a qualified person, for publication in a current newspaper, magazine, or journal.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_R.cfm#review</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2b2f8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Book Chapter Abstract</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A book chapter abstract is a brief, objective representation of the essential content of a book chapter, presenting the main points in the same order as the original but having no independent literary value.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/index.cfm#abstract</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2b2f9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Book Chapter Review</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A book chapter review is an evaluative account of a recent book chapter, usually written and signed by a qualified person, for publication in a current newspaper, magazine, or journal.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_R.cfm#review</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Inbook</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">An inbook is a part of a book, usually untitled. May be a chapter (or section or whatever) and/or a range of pages.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/BibTeX#Entry_Types</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Anthology</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">An anthology is a collection of extracts or complete works by various authors, selected by an editor for publication in a single volume or multivolume set. Anthologies are often limited to a specific literary form or genre (short stories, poetry, plays) or to a national literature, theme, time period, or category of author.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_A.cfm#anthology</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Monograph</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A monograph is a relatively short book or treatise on a single subject, complete in one physical piece, usually written by a specialist in the field. Monographic treatment is detailed and scholarly but not extensive in scope.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_M.cfm#monograph</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Referencebook</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A referencebook is a book designed to be consulted when authoritative information is needed, rather than read cover to cover. Reference books often consist of a series of signed or unsigned "entries" listed alphabetically under headwords or headings, or in some other arrangement (classified, numeric, etc.).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_r.cfm#referencebook</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Textbook</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A textbook is an edition of a book specifically intended for the use of students who are enrolled in a course of study or preparing for an examination on a subject or in an academic discipline, as distinct from the trade edition of the same title. Also refers to the standard work used for a specific course of study, whether published in special edition or not.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_T.cfm#textbook</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Encyclopedia</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">called Encyclopedia entries in CASRAI Dictionary</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">An enzyclopedia is a book or numbered set of books containing authoritative summary information about a variety of topics in the form of short essays, usually arranged alphabetically by headword or classified in some manner. An entry may be signed or unsigned, with or without illustration or a list of references for further reading. Headwords and text are usually revised periodically for publication in a new edition.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_E.cfm#encyclopedia</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Manual</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A manual refers to a book or pamphlet containing practical instructions, rules, or steps for performing a task or operation, assembling a manufactured object, or using a system or piece of equipment. Used synonymously with handbook (ODLIS Dictionary). A manual is a book that tells you how to do or operate something, especially one that comes with a machine (Grey Literature Typology.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_M.cfm#manual (ODLIS Dicationary); http://purl.org/ntk/gltype#manual (Grey Literature Typology)</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Otherbook</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Uncertain of definition</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">To books not specified other places?</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Journal</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A journal is a periodical devoted to disseminating original research and commentary on current developments in a specific discipline, subdiscipline, or field of study (example: Journal of Clinical Epidemiology), usually published in quarterly, bimonthly, or monthly issues sold by subscription (click here to see an example). Journal articles are usually written by the person (or persons) who conducted the research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_J.cfm#journal</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9e9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Journal Article</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; HEFCE; CASRAI</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A journal article is a self-contained nonfiction prose composition on a fairly narrow topic or subject, written by one or more authors and published under a separate title in a collection or periodical containing other works of the same form.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_A.cfm#article</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9ea-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Journal Article Abstract</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A journal article abstract is a brief, objective representation of the essential content of an article, presenting the main points in the same order as the original but having no independent literary value.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/index.cfm#abstract</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9eb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Journal Article Review</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A journal article review is an evaluative account of a recent of a newly published literary or scholarly work, usually written and signed by a qualified person, for publication in a current newspaper, magazine, or journal.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_R.cfm#review</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9ec-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference Proceedings</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A conference proceeding is a collection of articles, published abstracs or posters gathered from a conference. Can have several editors.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Pure4 Working group - DK</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9ed-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference Proceedings Article</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">called Conference Paper in CASRAI Dictionary</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">A conference proceedings article is an article that has been presented at a conference. Articles has been collected and published in a proceeding.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Pure4 Working group - DK</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9ee-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Letter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A letter (also known as "communication") is a brief description of important new research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Pure4 Working group - DK</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9ef-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Letter to Editor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A letter, usually printed at the discretion of the publisher on the editorial page of a newspaper or magazine, in which a reader expresses his or her views on the subject of a previously published article or editorial, or on the editorial policy of the publication in general, sometimes followed by a brief response from the editor(s).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_l.cfm#lettereditor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">PhD Thesis</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A PhD Thesis, is a Dissertation/Thesis that leads to the acquirement of a Ph.D. Degree.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Pure4 Working group - DK</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f1-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Doctoral Thesis</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">called Dissertation in CASRAI Dictionary.</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">A Doctoral Thesis is a Dissertation/Thesis that leads to the acquirement of a doctoral degree.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Pure4 Working group - DK</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f2-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Report</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; Grey Literature Typology; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://purl.org/ntk/gltype#report</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A report is a separately published record of research findings, research still in progress, or other technical findings, usually bearing a report number and sometimes a grant number assigned by the funding agency.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_R.cfm#report</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Short Communication</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A short communication is a concise, but independent report representing a significant contribution to a subject.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.ejbiotechnology.info/iaformato/short_communications.html</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f4-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Poster</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A poster is a visual presentation of an academic subject presented at a conference.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Pure4 Working group - DK</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Presentation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">Uncertain of definition</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">Presentation as in a speech? Paper presentation at a conference?</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f6-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Newsclipping</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">called Newspaper Article in CASRAI Dictionary</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">A newsclipping is an article published in a newspaper, newsmagazine, or online news service, reporting the details of a current event or the latest information on a topic of general interest. News stories are usually short and often unattributed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_N.cfm#newsstory</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f7-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Commentary</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDef cfLangCode="en" cfTrans="o">A commentary is a written explanation or criticism or illustration that is added to a book or other textual material.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Commentary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>eda2d9f8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Annotation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">An annotation is a brief note, usually no longer than two or three sentences, added after a citation in a bibliography to describe or explain the content or message of the work cited or to comment on it.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_A.cfm#annotation</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>640b32f5-da23-47e4-961d-46d106cc06b9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Transliteration</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">Rendering the characters of one alphabet in characters representing the same sound (or sounds) in another alphabet (example: Greek or Cyrillic into Roman). Each character is treated independently of the others.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_A.cfm#transliteration</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>f04aabeb-ee05-46b6-a7e8-1dc35bfd3c5d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Translation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfEx cfLangCode="en" cfTrans="o">A passage from a speech or written work, or an entire speech or work, put into the words of another language (English into Spanish) or into a more modern form of the same language (Old English or Middle English into contemporary English), usually to make the text more accessible to individuals who are unable to read it in the original language. Translations differ in the degree to which they follow the original. The name of the translator usually appears on the title page of a book, following the name of the author. A translation may have a parallel title in the source language. In library cataloging, the note Translation of: is added in the bibliographic description, giving the title in the original language.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_A.cfm#translation</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Translations of books and articles that identify modifications to the original edition, such as a new or revised preface.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/translations</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>2522c045-5090-4da2-824c-583e039e23b3</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Authored Book</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Books written by a single author or collaboratively based on research or scholarly findings generally derived from peer reviewed funding.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/books</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>f5e38c52-d56a-4878-879c-31526788b19d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Edited Book</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Books edited by a single author or collaboratively for the dissemination of research or scholarly findings that generally result from peer reviewed funding.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/edited-books</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>b7ddff91-81b9-42b1-8228-190329ea6557</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Chapter in Book</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">One of two ore more major divisions of a book or other work, each complete in itself but related in theme or plot to the division preceding and/or following it. In works of nonfiction, chapters are usually given a chapter title, but in works of fiction they may simply be numbered, usually in roman numerals. Chapters are listed in order of appearance by title and/or number in the table of contents in the front matter of a book.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.abc-clio.com/ODLIS/odlis_c.aspx#chapter</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Texts written by a single author or collaboratively based on research or scholarly findings and expertise in a field.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/book-chapters</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>af3f2342-4724-4d04-8246-cc30f50a4f6d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Scholarly Edition</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A scholarly edition of a text is an edition that is reliable and useful for scholarly purposes. In order to fulfill such purposes, a scholarly edition must live up to high standards.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.iva.dk/bh/core%20concepts%20in%20lis/articles%20a-z/scholarly_edition.htm</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>43afa201-2979-42b0-b283-ed609058d90a</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference Contribution</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/search/Conference</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>3acbc6f9-8b04-4117-8222-f39c84c7b6c6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Working Paper</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Preliminary versions of articles that have not undergone review but that may be shared for comment.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/documents/non-academic-funding-cv/1.1/contributions/outputs/publications/working-papers</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>93a40595-c066-4cb3-99a1-68f451e3a7cc</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Artefact</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">Something made or given shape by man, such as a tool or a work of art, esp an object of archaeological interest.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/artefact</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>2a10d453-7128-45dc-b5b0-040c0d06c7d7</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Devices and products</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfEvent_Class -->
+      <cfClassId>2e0a25cd-88b5-4018-8de2-c12b3a702cfe</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Performance</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">called Performance Art in CASRAI Dictionary</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">Collection of information records that, in combination, represent a full and up-to-date history of artistic or performance outputs resulting from, or related to, the person's research or scholarly activities. Works may be produced alone or collaboratively as a creative practice that lead to production and dissemination.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfEvent_Class -->
+      <cfClassId>71e46c84-243c-410f-9f61-63ec75323c8b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Exhibition</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">called Artistic Exhibition in CASRAI Dictionary</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">Showings of works of art under the direction of a curator, an artist or as a graduation exhibition.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/artistic-exhibitions</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPat_Class -->
+      <cfClassId>274e99d8-1e36-4b3e-a998-2a3384e79f64</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Patent / published patent application</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">called intellectual property in CASRAI: Collection of information records that, in combination, represent a full and up-to-date history of the intellectual property owned by the person and resulting from, or related to, the person's research activities.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class; cfResProd_Class; cfResPat_Class -->
+      <cfClassId>6a49719d-1226-454b-bff5-04b6fd3f141c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Composition</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/search/Composition</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class; cfResProd_Class; cfResPat_Class -->
+      <cfClassId>ab0efef8-6ef2-4509-ae10-8ccce30075d9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Design</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/search/Design</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>032f0d65-2461-492d-b718-2788ef5db869</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research report for external body.</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>ca47658a-322d-4010-94e6-81401dc5b565</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Confidential Report (for external body).</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>5b90f961-6489-4500-bb6a-5b60ead25a2d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Software</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary; Grey Literature Type</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Software is a generic term for computer programs and their associated documentation, as opposed to data used as input and generated as output.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://purl.org/ntk/gltype#software</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>898beff1-5f9d-4b8f-b9d8-660a783fae9a</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Website content</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary; Grey Literature Type</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">A website is a collection of related web pages, images, videos or other digital assets that are addressed relative to a common Uniform Resource Locator (URL), often consisting of only the domain name, or the IP address, and the root path ('/') in an Internet Protocol-based network. A web site is hosted on at least one web server, accessible via a network such as the Internet or a private local area network.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://purl.org/ntk/gltype#website</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Stand-alone locations on the web where multiple types of information on a specific theme are available. May include interactive features for contributions from readers.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/search/Website</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>3c610d3c-b62a-4889-811b-dc9dbe40b847</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Digital or visual media</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>b8da9b81-7cd8-4b33-88c5-28b41bbc49c9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research data sets and databases</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">called Data set in CASRAI</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">A series of structured observations, measurements or facts identified from the research which can be stored in a database medium.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/data-sets</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>7eb3f358-bfc1-45d4-9ec6-b16d99f0ded6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Other</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">HEFCE; RMAS project; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">http://www.ref.ac.uk/media/ref/content/subguide/11.Output_requirements.XLSX</cfDescrSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>a85940d9-ad65-4a8d-ae54-23dda97c406e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Journal Issue</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Periodical publications aimed at fostering intellectual debate and inquiry. Special journal issues are produced by editors with an established record of scholarship in the field and able to provide the direction of the theme. Journal issues bear a unique number of reference for publication.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/journal-issues</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResProd_Class -->
+      <cfClassId>b135c301-61d0-4d05-be98-e959f5c221dc</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Supervised Student Publications</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Articles on research findings published jointly with or supervised by the thesis advisor. The findings relate to research undertaken by the student or the supervisor’s program of research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/supervised-student-publications</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>3f8f2c15-fbea-4b38-b517-3901378a9f1b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Encyclopedia Entry</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Authored entries in a reference work or a compendium focusing on a particular domain or on all branches of knowledge.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/encyclopedia-entries</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>d4753dda-e7a0-4837-ae7d-648a8d85b62c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Magazine Article</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Articles in thematic publications published at fixed intervals.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/magazine-articles</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>71361e1a-03f1-4577-b91b-01cb87a2c280</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Dictionary Entry</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Entries of new words, new meanings of existing words, changes in spelling and hyphenation over a longer period of time, and grammatical changes.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/dictionary-entries</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>a79aca4a-3a43-4809-92a6-9ce690dd7f70</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Tool</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Series of observations, measurements or facts identified from the research. They include bibliographies, indices and catalogues of research collections; concordances and dictionaries; materials that facilitate access to archival holdings or collections such as repository guides, inventories of a group of manuscripts or of a body of archives, inventories or documentary materials, thematic guides to archival materials, records surveys and special indices; scholarly editions; and data series.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/research-tools</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>db7bca87-379e-4854-a0d6-f9567226b1a6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Online Resource</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Information accessible only on the web via traditional technical methods (ie hyperlinks).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/online-resources</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>6915f869-e12e-42e8-b1b7-13bbea303d64</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Test</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Assessments that include tests designed for general university selection, selection into specific courses or other evaluation purposes.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/publications/tests</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>154e80ab-e825-4f7c-9430-bdf7ee971425</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference Abstract</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Texts of a specified length that states the issue to be discussed in a proposed conference paper. It serves as the basis for the acceptance of the paper at a conference. The abstract is published along with the paper.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/conferences/conference-abstracts</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>93aa5afc-19e5-4995-99b5-47ee8c80b3fc</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Conference Poster</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Posters displayed in a conference setting and conveying research highlights in an efficient manner by compelling graphics. They may be peer-reviewed prior to acceptance and be published in the proceedings.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/conferences/conference-posters</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>d7e9d33a-20d4-447c-bd3f-6774afa23f4e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Musical Composition</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Original musical scores available in a format for dissemination.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/musical-compositions</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>849fcbfa-f863-4e80-b7b9-811ccc1fb9c1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Musical Performance</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Original musical scores available in a format for dissemination.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/musical-performances</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>ca4665dc-d9da-49c3-950d-f95699e28b10</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Radio/TV Program</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Programming produced for and broadcast on radio or TV.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/radiotv-programs</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>488c227d-ade1-45c5-bf13-77cec1e5033c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Script</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Written versions of a play, film, broadcast or other dramatic composition used in preparing for a performance and annotated with instructions for the performance.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/scripts</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>68bade0c-2ac6-4dd9-834e-dec1583a607f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Short Fiction</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Original literary texts (prose or poetry).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/short-fiction</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>c8b9bf7b-bb0c-493b-82aa-db9a5834f61e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Theatric</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Creation, production, dissemination of plays by professional theatre artists and organizations. The artifacts, such costumes, props, sets and scripts, may be the object of a public exhibit.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/theatric</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>b4a6438e-4bcb-4d8b-9363-4f6488861249</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Video Recording</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Works such as film, video, or new media developed as a result of an artistic practice. May serve for commercial purposes.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/video-recordings</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>2dedf523-a6eb-4bfc-87e0-bc046e20f551</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Visual Artwork</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Works such as film, video, or new media developed as a result of an artistic practice. May serve for commercial purposes.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/visual-artworks</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>5d46488d-2952-4c31-bcca-84cd3f13fe7e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Sound Design</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Art and process of manipulating audio elements to achieve a desired effect. It is employed in a variety of disciplines including film, theatre, music recording, and live music performance. It involves the manipulation of previously composed audio or the creative composition of new audio.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/sound-design</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>af08e1af-3d31-4b58-8ef1-8d5fc714a743</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Set Design</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Creations of theatrical, as well as film or television scenery (also known as stage design, scenic design or production design).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/set-design</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>41555114-5fdb-4ee9-b5e7-b3acb574310d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Light Design</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Works done within theatre or in relation to an art installation to design a production.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/light-design</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfEvent_Class -->
+      <cfClassId>77c9c66f-9e65-4876-8e82-34ac7c50582d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Choreography</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Dance compositions created for production and dissemination.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/artisticperformance/choreography</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>8b5e666b-6121-4b4d-b446-9ed6ad7ed35c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Curatorial/Museum Exhibitions</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Collection of information records that, in combination, represent a full and up-to-date history of the intellectual property owned by the person and resulting from, or related to, the person's research activities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/conferences</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>64b9ce43-e5ed-4df2-86d5-01bc46939fd5</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Intellectual Property</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Collection of information records that, in combination, represent a full and up-to-date history of the intellectual property owned by the person and resulting from, or related to, the person's research activities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>2d8d91dc-00ef-4982-a6d2-0700b34b47fd</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">License</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Signed agreements to exploit a piece of IP such as a process, product, data, or software.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/licenses</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>170136af-8bec-4b17-af16-c738633a3b96</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Disclosure</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Publications that establish inventions as prior art thereby preventing others from patenting the same invention or concept.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/disclosures</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>0f38dfac-b08c-4ed9-b627-df8f95d74bd5</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Registered Copyright</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Registered ownership of rights under a system of laws for promoting both the creation of and access to artistic, literary, musical, dramatic and other creative works.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/registered-copyrights</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>723f6119-ffac-4f4c-99d2-9c34eb644115</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Trademark</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Marks such as a name, word, phrase, logo, symbol, design, image of a product or service that indicates the source and provides the right to control the use of the identifier.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/intellectual-property/trademarks</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>6b7fdebc-f169-4a7a-89b4-539ff69c5dcd</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Standard and Policy</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The development of a rule or principle that is used as a basis for judgement.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/standards-and-policies</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>c03694e5-f58b-4a37-83ff-5f8285c67f66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Technical Standard</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Technical Standards (industrial or otherwise) that have originated from the research projects in which new protocols, methods or materials may be developed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/technical-standards</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>b8b97010-577d-4ba2-9195-0b6cba3f0866</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Techniques</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A practical methods or skills applied to particular tasks identified as part of the research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/research-techniques</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>76cf4c24-7f15-41b9-995f-889cec876b30</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Invention</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Practical and original outputs arising from research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/inventions</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Output Types -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>88478041-0fa4-4396-9246-6985ec0e9e6e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Litigation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The act or process of contesting at law.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/contributions/outputs/other-outputs/litigation</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PeerReviews.xml
+++ b/vocab/xml/PeerReviews.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>4bdfc4ac-7c74-456d-9d3b-b1e4267b90a9</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Peer Reviews</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">Whether or not the output is known to be peer-reviewed.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Peer Reviews -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>df943548-c67e-4c96-8c4f-1c0aa144b1c0</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Yes</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Where the output has been subject to assessment and critique by independent experts.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Peer Reviews -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>0c7c83d0-5513-4eaa-b5cf-d01374c3d2eb</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">No</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Where the output has not been subject to assessment and critique by independent experts.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Peer Reviews -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>22b56ddc-87e8-4023-ab56-e661dcb8ffd3</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Unknown</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Where it is unknown whether the output has been subject to assessment and critique by independent experts.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonContactDetails.xml
+++ b/vocab/xml/PersonContactDetails.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>05cc5ff9-bc58-4743-ab59-46e5013e0039</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Contact Details</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">A person's electronic and postal contact coordinates. This scheme contains CERIF vocabulary terms applicable in the cfPerson_ElectroniAddress or cfPerson_PostAddress link entity, being thus person contact details.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac41-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Fax</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac42-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Email</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details; Electronic Address Types -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr; cfEAddr_Class -->
+      <cfClassId>35d43364-2160-4b6c-a487-5019458321e8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Professional Email</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr -->
+      <cfClassId>4523402a-0bae-4716-a5d7-77411b74d5f6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Personal Email</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>20476135-bc75-40b4-b5f0-f05543e919c6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Skype</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>95bff29c-338f-4790-80ac-c39ec3bc72f4</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Twitter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>beb680a9-4504-417f-b444-65ff289c5952</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Facebook</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>48ed3997-8f3b-41bd-94c5-ba37df71c263</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">LinkedIn</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac44-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Phone</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac45-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Public Access</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details; Organisation Contact Details -->
+      <!-- usage with CERIF: cfPers_EAddr; cfOrgUnit_EAddr -->
+      <cfClassId>9931ac46-3864-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Corporate Access</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Contact Details -->
+      <!-- usage with CERIF: cfPers_Paddr -->
+      <cfClassId>6947fabb-a277-4f8f-b148-c6b41a936c57</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Person Professional Postal Address</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The work address of a person to which physical correspondance can be delivered.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonDegreeLevelsOfStudy.xml
+++ b/vocab/xml/PersonDegreeLevelsOfStudy.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>a1a55095-45c2-456c-9869-add5d726c676</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Degree Levels of Study</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The level of degree a person is studying for.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Degree Levels of Study -->
+      <!-- usage with CERIF: cfPers_Srv -->
+      <cfClassId>a32a9785-0d15-48ba-aca8-0be319578e5e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Master</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A degree above Bachelor level, that normally takes 1 to 2 years of effort.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Degree Levels of Study -->
+      <!-- usage with CERIF: cfPers_Srv -->
+      <cfClassId>f7d5892b-8be3-42fa-8d4b-e18fe9bed062</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Doctorate</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A degree above Masters level, that normally takes 3 to 4 years of effort.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Degree Levels of Study -->
+      <!-- usage with CERIF: cfPers_Srv -->
+      <cfClassId>73451d3c-9afa-4484-8404-cd1518ef508b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Higher Doctorate</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A degree above doctorate level, that normally is associated with a life-time achievement.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonEmploymentTypes.xml
+++ b/vocab/xml/PersonEmploymentTypes.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>e9616dbd-0d38-4b7d-a6cd-3c4df1e95462</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Employment Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_OrganisationUnit link entity with respect to employment, being thus employment types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Employment Types; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>b9bd41f0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Administrator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is administrator at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has administrator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, administrator is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Administrator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities (CERIF Task Group). An administrator directly employed by an organisation (RMAS Project).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">An administrator is a person responsible for the performance or management of administrative business operations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Administrator</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An administrator directly employed on an activity or a person not directly involved in the activity but with information related to the activity (e.g. finance, computing, hr), where they are not a contact.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types; Person Project Engagements; Activity Finance Categories -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfProj_Meas -->
+      <cfClassId>8adcdf20-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Technician</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is technician at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has technician</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, technician is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Technician" identified by its cfClassificationIdentifier (a uuid) and reused inlink entities. (CERIF Task Group) A permanent Research staff. (RMAS project)</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The full economic cost associated with pool technicians used in the activity (Activity Finance Category). Someone, whose duties include the construction, maintenance and operation of the equipment involved in laboratory research; the preparation of samples that constitute the raw material for experiments; the running of those experiments; and the recording, presentation and - on occations - some of the analysis and interpretation of the data that is produced. In undertaking these tasks, technicians work closely with academic researchers and make an indispensible contribution to the production of scientific knowledge, and through formal, and, in particular, informal contributions to the teaching of practical skills, they help to educate students (http://www.kcl.ac.uk/sspp/departments/management/people/academic/lewisgatsbyreport.pdf).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A technician is someone known for high skill in some intellectual or artistic technique.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=technician</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>7a642fac-777a-43b7-a0c1-90b88428e125</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Academic Teaching only</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is academic teaching only staff</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has academic teaching only staff</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A permanent teaching stuff.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>df5ec85e-c645-449f-9473-41c9f9923cb7</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Associate</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is research associate at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has research associate</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Research-only, non-teaching staff, not member of permanent staff.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>fd742fb8-fa7f-40b4-a015-c7deb93902f6</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Academic Research</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is academic researcher at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has academic researcher</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A permanent research and teaching staff.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Person Employment Types; Person Project Engagements -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfPers_OrgUnit; cfPers_Proj -->
+      <cfClassId>eda28bc5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Supporter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is supporter of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has supporter</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">The person not directly involved in the activity but contributing to maintaining the infrastructure.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A supporter is someone who supports or champions something.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=supporter</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonEventInvolvements.xml
+++ b/vocab/xml/PersonEventInvolvements.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>b4de9a8f-3a4d-4233-9a9f-3b624e4ad74f</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Event Involvements</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Event link entity being thus person event involvements.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Person Event Involvements -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfPers_Event -->
+      <cfClassId>ddc3dd10-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Participant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is participant in</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has participant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, participant is a role e.g. in the person-project relationship; that is, the classification term (cfTerm) "Participant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A participant is someone who takes part in an activity</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=participant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Organisation Roles; Person Project Engagements; Organisation Funding Roles -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_ResPubl; cfPers_ResPat; cfPers_ResProd; cfPers_Event; cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund -->
+      <cfClassId>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contributor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CIA project; RMAS Project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contributor to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contributor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_Event -->
+      <cfClassId>ee155a46-9850-48aa-98c2-e70ecb0f5d3b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Performer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is performer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has performer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person who performs at an event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_Event -->
+      <cfClassId>92e7478e-5a7c-4c72-a14e-a5770619251e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Choreographer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is choreographer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has choreographer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A Choreographer is a person who creates dances. This person decides what the steps will be, and then a dancer performs the steps. Some people have jobs as choreographers. Some people do it just for fun. This person gets to work with a lot of different dancers, including celebrities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://simple.wikipedia.org/wiki/Choreographer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>2b3ba8f1-5620-42c9-8549-7d34ed37f968</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Interviewee</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is interviewee at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has interviewee</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Person that is interviewed at an event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>d1ee35f1-c4c6-4651-a760-06a3828a61c1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Speaker</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is speaker at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has speaker</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Person that speaks at an event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>1ca8d2bc-9424-4df4-ae4b-8ce65239c770</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Panel Participant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is panel participant</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has panel participant</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Member of a discussion panel at an event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>1869a08e-3257-457b-9278-ed32bd915ee8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Programme Committee Member</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is programme committee member at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has programme committee member</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Member of the group of people who organise and manage the content of the event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>dc42714f-56de-441f-9161-a51d8edbcb8d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reporter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reporter at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reporter</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Person to report about the event (e.g. journalist) to the general public.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>86bacee1-49d8-429d-97aa-5f4918d3ae88</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Rapporteur</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is rapporteur at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has rapporteur</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Person to report about the 'technical' content of an event (also implies part of event, e.g. session) for the benefit of people attending or wished to attend (i.e. subject community).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>d9a6b8e4-38af-4492-b178-3326173ec657</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Peer Reviewer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is peer reviewer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has peer reviewer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Subject expert reviewing content submissions to inform the process for selection of content at the event. This may also involve feedback to contributors to improve content.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements -->
+      <!-- usage with CERIF: cfPers_Event -->
+      <cfClassId>b4ba809e-60d7-411c-af62-792100c45341</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Organiser</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is organiser at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has organiser</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The person responsible for organizing the event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonFundingRoles.xml
+++ b/vocab/xml/PersonFundingRoles.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af934-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Funding Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Funding link entity, being thus person funding roles such as manager or contact, where funding subsumes funding programme, tender, call, and not the income as such, which would be a financial means and as such in CERIF be a measurement.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Person Funding Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund -->
+      <cfClassId>79a2e340-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Manager</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is manager of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has manager</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A manager is someone who controls resources and expenditures.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contact</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contact of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contact</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">The person to be contacted in a particular circumstance (e.g. finance).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">In CERIF terms, contact is a role in e.g. the person-project, organisation-funding, ... relationship; that is, the classification term (cfTerm) "Contact" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contact is a communicative interaction.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contact</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Output Contributions -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfOrgUnit_Fund; cfPers_Fund; cfPers_ResPat -->
+      <cfClassId>33551370-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Applicant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is applicant of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has applicant</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An applicant is an organisation that submits a grant application on behalf of a consortium, partnership or network of participating organisations; the applicant represents and acts on behalf of the group of participating organisation in its relations with the Agency; if the grant application is selected, the Applicant will become the main beneficiary (see Beneficiary definition below) and will sign the grant agreement on behalf of the participating organisations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://eacea.ec.europa.eu/erasmus_mundus/tools/glossary_en.php</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An applicant is also called proposer.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonNames.xml
+++ b/vocab/xml/PersonNames.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>7375609d-cfa6-45ce-a803-75de69abe21f</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Names</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable with the cfPersonName_Person link entity, being thus a vocabulary of person name variants.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Names -->
+      <!-- usage with CERIF: cfPersName_Pers -->
+      <cfClassId>64f0eb00-462d-4737-8033-7efac82decf3</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Passport Name</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The name of the person as printed in the passport</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Names -->
+      <!-- usage with CERIF: cfPersName_Pers -->
+      <cfClassId>bdcf213d-df3e-4af4-a2ea-69ca26e98cd4</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Short Name</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The name of the person in short.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Names -->
+      <!-- usage with CERIF: cfPersName_Pers -->
+      <cfClassId>5f3df96e-eb12-46b1-8458-c85914e2fc4c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Initials</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The initials deduced from a person's name.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Names -->
+      <!-- usage with CERIF: cfPersName_Pers -->
+      <cfClassId>55f90543-d631-42eb-8d47-d8d9266cbb26</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Presented Name</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The given and surname of the reference.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-activity-profile-v0.9-draft/1.1.0/funding-requests/references/presented-name</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Names -->
+      <!-- usage with CERIF: cfPersName_Pers -->
+      <cfClassId>c54976a0-6793-4e62-b77d-7871ccb6ef0b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Previous Family Name</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CASRAI Dictionary</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The previous surname of the person if, for example, there has been a change due to marriage.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dictionary.casrai.org/research-personnel-profile/1.1.0/identification/person-info/previous-family-name</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonOrganisationRoles.xml
+++ b/vocab/xml/PersonOrganisationRoles.xml
@@ -1,0 +1,597 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>994069a0-1cd6-11e1-8bc2-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Organisation Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_OrganisationUnit link entity without further specification, being thus Person Organisation Roles.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Titles -->
+      <!-- usage with CERIF: cfPers_OrgUnit, cfPers_Class -->
+      <cfClassId>3bb53320-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Professor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is professor at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has professor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A professor is someone who is a member of the faculty at a college or university.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=professor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Titles -->
+      <!-- usage with CERIF: cPers_OrgUnit; cfPers_Class -->
+      <cfClassId>a27e5ca7-3d20-4272-9054-7db550e2a053</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Associate</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is associate of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has associate</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, associate is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Associate" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An associate is a person with subordinate membership in a society, institution, or commercial enterprise.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=associate</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>980965b0-1cd5-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Affiliation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is affiliated with</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has affiliate</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, affiliation is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Affiliation" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An affiliation is a formal connection,</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>081e85f0-1cd7-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Subaffiliation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is subaffiliated with</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has subaffiliate</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, subaffiliation is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Subaffiliation" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A subaffiliation is a formal subconnection of an affiliation.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>6125f750-1cd7-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Head</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is head of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has head</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, head is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Head" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A person who is in charge</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=head</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>c302c2f0-1cd7-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Employee</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is employed by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has employee</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, employee is a role e.g. in the person-organisation relationship; that is, the classification term (cfTerm) "Employee" identified by its cfClassificationIdentifier (a uuid) and reused in the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A worker who is hired to perform a job</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Employee</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit -->
+      <cfClassId>cb3e0010-1cd7-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Member</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is member of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has member</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the member role happens e.g. within the relationships person-organisation, person-project; organisation-organisation, that is, the classification term (cfTerm) "Member" identified by its cfClassificationIdentifier (a uuid), and reused with e.g. the cfPerson_OrganisationUnit; cfProject_Person; cfOrganisationUnit_OrganisationUnit relationships. A person can be a member of multiple organisations. An organization can be a member of another organization, or a state that belongs to a group of nations.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A member is anything that belongs to a set or class.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=member</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>68971130-1cd8-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Director</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is director of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has director</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, director is e.g. a role in the person-organisation relationship; that is, the classification term (cfTerm) "Director" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A director is someone who controls resources and expenditures</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=director</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>885eeb00-1cf6-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Deputy Director</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is deputy director of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has deputy director</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, deputy director is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Deputy Director" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A deputy director is a person appointed to represent or act on behalf of the director</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=deputy</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>57f7a7d0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Dean</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is dean of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has dean</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, dean is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Dean" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A dean is an administrator in charge of a division of a university or college.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=dean</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>612163a0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Principle</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is principle of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has principle</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, principle is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Principle" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A principle is a person who empowers another to act as his or her representative; The person having prime responsibility for an obligation as distinguished from one who acts as surety or as an endorser. (law)</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.yourdictionary.com/principal</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>68cdce40-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Head of Department</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is head of department of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has head of department</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, head of department is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Head of Department" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A head of department is a person who is in charge of a specialized division of a large organization.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=department; http://wordnetweb.princeton.edu/perl/webwn?s=headhttp://wordnetweb.princeton.edu/perl/webwn?s=department; http://wordnetweb.princeton.edu/perl/webwn?s=head</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>7210b760-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Group Leader</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is group leader of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has group leader</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, group leader is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Group Leader" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A group leader is a person who rules or guides or inspires others or any number of entities (members) considered as a unit.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=group; http://wordnetweb.princeton.edu/perl/webwn?s=leader</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Person Funding Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund -->
+      <cfClassId>79a2e340-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Manager</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is manager of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has manager</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A manager is someone who controls resources and expenditures.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>8418a710-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Spokesperson</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is spokesperson of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has spokesperson</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, spokesperson is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Spokesperson" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A spokesperson is an advocate who represents someone else's policy or purpose.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=spokesperson</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>94d55210-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Fellow</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is fellow of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has fellow</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, fellow is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Fellow" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A fellow is a member of a learned society.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=fellow</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Person Output Contributions; Organisation Project Engagements; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfPers_ResPubl; cfProj_OrgUnit; cfOrgUnit_ResPubl -->
+      <cfClassId>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reviewer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reviewer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reviewer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A reviewer is someone who reads manuscripts and judges their suitability for publication.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>abf21190-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation contracted to undertake a specific bounded (time and specification) subset of an activity. Normally such an organisation would not retain an interest in any IP generated from the activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfProj_OrgUnit -->
+      <cfClassId>b272a660-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Subcontractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is subcontractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has subcontractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A subcontractor is someone who enters into a subcontract with the primary contractor.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=subcontractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>057a7d50-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Engineer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is engineer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has engineer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit or cfProject_Person link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A person who uses scientific knowledge to solve practical problems.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=engineer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit; -->
+      <cfClassId>c6e02460-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Secretary</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is secretary at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has secretary</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, secretary is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Secretary" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A secretary is a person who is head of an administrative department of government, an assistant who handles correspondence and clerical work for a boss or an organization</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=secretary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>ebd55ab0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Researcher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is researcher at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has researcher</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A researcher is a scientist who devotes himself to doing research (Wordnet). Permanent research, non-teaching staff (RMAS Project).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=researcher</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>f401a3b0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Junior Researcher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is junior researcher at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has junior researcher</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, junior researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Junior Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A junior researcher is a scientist who devotes himself to doing research but younger; lower in rank; shorter in length of tenure or service</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Junior; http://wordnetweb.princeton.edu/perl/webwn?s=researcher</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>faf322c0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Senior Researcher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is senior researcher at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has senior researcher</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, senior researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Senior Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A senior researcher is a scientist who devotes himself to doing research and is older; higher in rank; longer in length of tenure or service</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=senior; http://wordnetweb.princeton.edu/perl/webwn?s=researcher</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>04c3f400-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Consultant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is consultant at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has consultant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A consultant is an expert who gives advice.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=consultant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>0bb17b70-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Junior Consultant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is junior consultant at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has junior consultant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, junior consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Junior Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A junior consultant is an expert who gives advice and that is younger; lower in rank; shorter in length of tenure or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=junior; http://wordnetweb.princeton.edu/perl/webwn?s=consultant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>13633d40-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Senior Consultant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is senior consultant at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has senior consultant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, senior consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Senior Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A senior consultant is an expert who gives advice that is older; higher in rank; longer in length of tenure or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=consultant; http://wordnetweb.princeton.edu/perl/webwn?s=senior</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>1a3c5250-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Lecturer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is lecturer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has lecturer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A lecturer is someone who lectures professionally, a public lecturer at certain universities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=lecturer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>23b16f00-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Junior Lecturer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is junior lecturer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has junior lecturer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, junior lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Junior Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A junior lecturer is someone who lectures professionally, a public lecturer at certain universities and is younger; lower in rank; shorter in length of tenure or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=lecturer; http://wordnetweb.princeton.edu/perl/webwn?s=junior</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>2b20d0a0-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Senior Lecturer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is senior lecturer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has senior lecturer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, senior lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Senior Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A senior lecturer is someone who lectures professionally, a public lecturer at certain universities and is older; higher in rank; longer in length of tenure or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=senior; http://wordnetweb.princeton.edu/perl/webwn?s=lecturer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>33661fe0-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Guest Lecturer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is guest lecturer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has guest lecturer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, guest lecturer is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Guest Lecturer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A guest lecturer is someone who lectures professionally, a public lecturer at certain universities and is a visitor to whom hospitality is extended.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=guest; http://wordnetweb.princeton.edu/perl/webwn?s=lecturer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>45aec210-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Assistant Professor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is assistant professor at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has assistant professor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, assistant professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Assistant Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An assistant professor is a university teacher lower in rank than an associate professor.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.thefreedictionary.com/assistant+professor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>4dfbb270-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Honorary Professor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is honorary professor at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has honorary professor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, honorary professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Honorary Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An honorary professor is given an honor without the normal duties of a professor, someone who is a member of the faculty at a college or university.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=honorary; http://wordnetweb.princeton.edu/perl/webwn?s=professor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>55ddd310-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Visiting Professor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is visiting professor at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has visiting professor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, visiting professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Visiting Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A visiting professor is in the activity of a professor making visits.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=visiting; http://wordnetweb.princeton.edu/perl/webwn?s=professor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>5d1534c0-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Doctor (med)</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is doctor (med) at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has doctor (med)</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, doctor (med) is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Doctor (med)" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A doctor (med) is a licensed medical practitioner.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Doctor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>64af4fe0-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Fellow</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is research fellow at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has research fellow</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, research fellow is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Research Fellow" identified by its cfClassificationIdentifier (a uuid) and reused in in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The title of research fellow is used to denote a research position at a university or similar institution, usually for academic staff or faculty members. A research fellow may act either as an independent investigator or under the supervision of a principal investigator.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Research_fellow</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>6c68b2d0-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Postdoc</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is postdoc at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has postdoc</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, postdoc is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Postdoc" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A PostDoc is a scholar or researcher who is involved in academic study beyond the level of a doctoral degree</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Postdoc</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>727f6240-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">PhD Student</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is phd student at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has phd student</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, phd is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "PhD" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">Doctor of Philosophy, abbreviated to PhD, or Ph.D. in English-speaking countries, for the Greek διδάκτω�? φιλοσοφίας (Latin philosophiae doctor). Here φιλοσοφία/philosophy, literally translating tο "the love of wisdom", is used in the original Greek sense, loosely meaning "the pursuit of in depth knowledge" and does not refer to the scientific field philosophy.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Doctor_of_Philosophy</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A Phd or doctor's degree; doctorate is usually based on at least 3 years graduate study and a dissertation; the highest earned academic degrees conferred by a university.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=PhD</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>7a510820-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Assistant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is research assistant at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has research assistant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, research assistant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Research Assistant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A research assistant (in some institutions referred to as research officer) is a researcher employed, often on a temporary contract,[1] by a university or a research institute, for the purpose of assisting in academic research. Research assistants are not independent and not directly responsible for the outcome of the research and are responsible to a supervisor or principal investigator. Research assistants are often educated to degree level[2] and might be enrolled in a postgraduate degree programme. Although a research assistant is normally appointed at graduate level, so-called undergraduate research assistant are also sometimes appointed to support research. Similarly a postdoctoral research assistant who has recently been awarded a doctoral degree, may hold a temporary appointment as a research assistant, especially for position without any autonomy and research independence that requires a high degree of reliability.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Research_assistant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>80cae630-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reader</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reader at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reader</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, reader is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Reader" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A reader is a public lecturer at certain universities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=reader</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>91784ef0-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Teaching Fellow</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is teaching fellow at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has teaching fellow</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, teaching fellow is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Teaching Fellow" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A teaching fellow is a particular teaching role at some universities. In the USA a teaching fellow is an advanced graduate student who serves as the primary instructor for an undergraduate course. In the UK, teaching fellows are more commonly full members of academic staff who have the equivalent rank and pay as 'traditional' research-active academic staff.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Teaching_fellow</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>99c34380-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Teaching Assistant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is teaching assistant at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has teaching assistant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, teaching assistant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "teaching assistant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A teaching assistant is an individual who assists a professor or teacher with instructional responsibilities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Teaching_assistant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>a3bf6a80-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Casual</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is casual at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has casual</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, casual is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Casual" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A caual is a person without or seeming to be without plan or method.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=casual</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit -->
+      <cfClassId>a9fc3f90-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Expert</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is expert at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has expert</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, expert is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Expert" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An expert is a person with special knowledge or ability who performs skillfully.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=expert</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Organisation Roles; Person Project Engagements; Organisation Funding Roles -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_ResPubl; cfPers_ResPat; cfPers_ResProd; cfPers_Event; cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund -->
+      <cfClassId>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contributor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CIA project; RMAS Project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contributor to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contributor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonOutputContributions.xml
+++ b/vocab/xml/PersonOutputContributions.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>b7135ad0-1d00-11e1-8bc2-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Output Contributions</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_ResultPublication link entity - being person output contribution.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Person Output Contributions; Organisation Project Engagements; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfPers_ResPubl; cfProj_OrgUnit; cfOrgUnit_ResPubl -->
+      <cfClassId>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reviewer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reviewer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reviewer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A reviewer is someone who reads manuscripts and judges their suitability for publication.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Organisation Roles; Person Project Engagements; Organisation Funding Roles -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_ResPubl; cfPers_ResPat; cfPers_ResProd; cfPers_Event; cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund -->
+      <cfClassId>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contributor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CIA project; RMAS Project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contributor to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contributor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_Event -->
+      <cfClassId>ee155a46-9850-48aa-98c2-e70ecb0f5d3b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Performer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is performer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has performer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person who performs at an event.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_Event -->
+      <cfClassId>92e7478e-5a7c-4c72-a14e-a5770619251e</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Choreographer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is choreographer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has choreographer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A Choreographer is a person who creates dances. This person decides what the steps will be, and then a dancer performs the steps. Some people have jobs as choreographers. Some people do it just for fun. This person gets to work with a lot of different dancers, including celebrities.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://simple.wikipedia.org/wiki/Choreographer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Output Contributions -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfOrgUnit_Fund; cfPers_Fund; cfPers_ResPat -->
+      <cfClassId>33551370-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Applicant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is applicant of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has applicant</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An applicant is an organisation that submits a grant application on behalf of a consortium, partnership or network of participating organisations; the applicant represents and acts on behalf of the group of participating organisation in its relations with the Agency; if the grant application is selected, the Applicant will become the main beneficiary (see Beneficiary definition below) and will sign the grant agreement on behalf of the participating organisations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://eacea.ec.europa.eu/erasmus_mundus/tools/glossary_en.php</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An applicant is also called proposer.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl -->
+      <cfClassId>49815870-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Author</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is author of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has author</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An author is the person or corporate entity responsible for producing a written work (essay, monograph, novel, play, poem, screenplay, short story, etc.) whose name is printed on the title page of a book or given elsewhere in or on a manuscript or other item and in whose name the work is copyrighted. A work may have two or more joint authors. In library cataloging, the term is used in its broadest sense to include editor, compiler, composer, creator, etc</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_e.cfm#author</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>505eb340-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Author (numbered)</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is author (numbered) of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has author (numbered)</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">e.g. first author, second author ... of a publication</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">In CERIF this role requires a cfFraction attribute to indicate the number of authorschip.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>5a4c3440-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Author (percentage)</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is author (percentage) of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has author (percentage)</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">e.g. 50% author of a publication</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">In CERIF this role requires a cfFraction attribute to indicate the percentage of authorschip.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>60f2a090-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Creator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is creator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has creator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An entity primarily responsible for making the resource.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://dublincore.org/documents/dces/#creator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>708b3df0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Editor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is editor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has editor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person who prepares for publication the work(s) of one or more other authors. An editor may be responsible for selecting material included in a collection or for preparing manuscript copy for the printer, including annotation of the text, verification of the accuracy of facts and bibliographic citations, polishing grammar and style, organizing front and back matter, etc. Periodicals and large reference works often have a general editor or editor-in-chief who supervises the work of an editorial staff.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_e.cfm#editor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>7ef398b1-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Translator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is translator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has has translator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person who renders speech or text from one language in another or from an older form of a language into a more modern form. Translations of a work often differ in fidelity to the original. Name of translator usually appears on the title page of a book, following the name of the author.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_t.cfm#translator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event -->
+      <cfClassId>7ef398b2-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Publisher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is publisher of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has publisher</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person or corporate entity that prepares and issues printed materials for public sale or distribution, normally on the basis of a legal contract in which the publisher is granted certain exclusive rights in exchange for assuming the financial risk of publication and agreeing to compensate the author, usually with a share of the profits.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_t.cfm#publisher</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Organisation Output Contributions; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfOrgUnit_ResPubl; cfProj_OrgUnit -->
+      <cfClassId>7ef398b3-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Commissioner</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is commissioner of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has commissioner</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">The organisation that wishes the work to be undertaken (this might be the lead funder in a consortium funded project).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A government administrator, a member of a commission.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_t.cfm#commissioner</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Person Output Contributions; Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfPers_ResPat; cfPers_ResProd -->
+      <cfClassId>7ef398b4-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Group Authors</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is group authors of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has group authors</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Any number of authors considered as a unit.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfPers_Proj -->
+      <cfClassId>7ef3bfc0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Subject</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is subject of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has subject</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A person on which an experiment is performed.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Any one of the topics or themes of a work, stated explicitly in the text or title or implicit in its message. In library cataloging, a book or other item is assigned one or more subject headings as access points, to assist users in locating its content by subject. In abstracting and indexing services, the headings assigned to represent the content of a document are called descriptors</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_s.cfm#subject</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>7e2e67e4-e085-406c-a9c3-2a3df2bfc376</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Illustrator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is illustrator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has illustrator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An artist who makes illustrations (for books or magazines or advertisements etc.).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=illustrator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPubl -->
+      <cfClassId>5282d01e-f788-42b5-9ccb-eb8cc0626d4b</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Guest Editor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is guest editor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has guest editor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">As guest-editing can be a demanding and time-consuming project, most volumes are organized by a team of people rather than an individual. Two or three editors tends to work best.</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPat -->
+      <cfClassId>5b6b6bf2-c949-4c9e-ab4c-ffaa196b8355</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Patentee</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is patentee of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has patentee</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The inventor to whom a patent is issued.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=patentee</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResPat -->
+      <cfClassId>74e43aa3-233d-4a59-b9bf-0bd733c9e9f8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Holder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is holder of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has holder</cfRoleExprOpp>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>d03c6c91-1c65-442e-82e2-a2194b0e1907</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Designer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is designer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has designer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Someone who creates plans to be used in making something (such as buildings).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=designer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>97fb8809-d23d-4826-b99d-6b5d666e1f33</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Artist</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is artist of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has artist</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">An artist is a person engaged in one or more of any of a broad spectrum of activities related to creating art, practicing the arts and/or demonstrating an art. The common usage in both everyday speech and academic discourse is a practitioner in the visual arts only.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Artist</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>62226b46-2ea3-46f4-b924-80ea42055587</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Constructor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is constructor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has constructor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Someone who contracts for and supervises construction (as of a building)).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=constructor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>b14b3a56-64c0-4d59-ad64-7d7af09ea529</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Composer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is composer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has composer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Someone who composes music as a profession.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=composer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>aa82a7f8-8713-43f2-b7b4-e4d2196b1a3c</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Programmer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is programmer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has programmer</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person who designs and writes and tests computer programs.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=programmer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>cd5bb616-a187-4600-b2d2-0eac76a3be63</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Analyst</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is analyst of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has analyst</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Someone who is skilled at analyzing data.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=analyst</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>6d95cff9-0ae3-4dc2-8566-5a31fd8e75f9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Validator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is validator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has validator</cfRoleExprOpp>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions -->
+      <!-- usage with CERIF: cfPers_ResProd -->
+      <cfClassId>f94f7ec1-263a-4898-8286-4e7ba44af0d1</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Tester</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is tester of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has tester</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Someone who administers a test to determine your qualifications.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=tester</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonProfessionalRelationships.xml
+++ b/vocab/xml/PersonProfessionalRelationships.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6b2b7d24-3491-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Professional Relationships</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Person link entity, being thus an interpersonal structure.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Person Professional Relationships -->
+      <!-- usage with CERIF: cfProj_Pers; cfPers_Pers -->
+      <cfClassId>bc34dc30-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Co-Investigator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is co-investigator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has co-investigator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, co-investigator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Co-Investigator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A co-investitagor is also called co-promoter (quite often from different organizations). A co-investigator, fellow worker, workfellow (an associate that one works with).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>6b2b7d22-3491-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Mentor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group, RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is mentor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has mentor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A mentor is a wise and trusted guid and advisor.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=mentor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>6b2b7d23-3491-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Supervisor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is supervisor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has supervisor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person wich the official task of overseeing the work of a person or group.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=supervisor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>ab0ed712-6e50-46a5-8fa2-5d9b87c27e6d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Co-Supervisor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is co-supervisor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has co-supervisor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Is an additional member of the supervisory team, that guides a research student through their programme of studies. Often he/she has complementory expertise to the supervisor.</cfDef>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>3ccd035b-bc79-477e-aa6c-0bd3606f85c8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">External Supervisor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is external supervisor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has external supervisor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A co-supervisor that is external to the host institution of the research student.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>81d0d105-216f-42f0-8c96-a87ba2adfa41</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Advisor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is advisor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has advisor</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person that has an adhoc, informal input into the work of the supervisory team.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>1d689234-c537-4bba-b59a-2d85e1efcd1d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Colleague</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is colleague of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has colleague</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A co-worker, fellow worker, workfellow (an associate that one works with.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=colleague</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Professional Relationships -->
+      <!-- usage with CERIF: cfPers_Pers -->
+      <cfClassId>78883ba6-a5ac-45d4-a2e2-20b3f7f43a63</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Co-Researcher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is co-researcher of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has co-researcher</cfRoleExprOpp>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonProjectEngagements.xml
+++ b/vocab/xml/PersonProjectEngagements.xml
@@ -1,0 +1,347 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>94fefd50-1d00-11e1-8bc2-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Project Engagements</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfProject_Person link entity with respect to person project engagement.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit -->
+      <cfClassId>cb3e0010-1cd7-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Member</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is member of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has member</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the member role happens e.g. within the relationships person-organisation, person-project; organisation-organisation, that is, the classification term (cfTerm) "Member" identified by its cfClassificationIdentifier (a uuid), and reused with e.g. the cfPerson_OrganisationUnit; cfProject_Person; cfOrganisationUnit_OrganisationUnit relationships. A person can be a member of multiple organisations. An organization can be a member of another organization, or a state that belongs to a group of nations.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A member is anything that belongs to a set or class.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=member</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Person Funding Roles -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund -->
+      <cfClassId>79a2e340-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Manager</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is manager of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has manager</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, the manager role happens e.g. within the relationships person-organisation or person-project; that is, the classification term (cfTerm) "Manager" identified by its cfClassificationIdentifier (a uuid), and reused with the e.g. cfPerson_OrganisationUnit or cfProject_Person relationships.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A manager is someone who controls resources and expenditures.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>8418a710-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Spokesperson</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is spokesperson of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has spokesperson</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, spokesperson is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Spokesperson" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A spokesperson is an advocate who represents someone else's policy or purpose.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=spokesperson</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Person Output Contributions; Organisation Project Engagements; Organisation Output Contributions -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfPers_ResPubl; cfProj_OrgUnit; cfOrgUnit_ResPubl -->
+      <cfClassId>9ef1ab40-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Reviewer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is reviewer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has reviewer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, reviewer is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Reviewer" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A reviewer is someone who reads manuscripts and judges their suitability for publication.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=reviewer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Inter-Organisational Structure; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>abf21190-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation contracted to undertake a specific bounded (time and specification) subset of an activity. Normally such an organisation would not retain an interest in any IP generated from the activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contractor is someone (a person or firm) who contracts to build things, (law) a party to a contract.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfProj_OrgUnit -->
+      <cfClassId>b272a660-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Subcontractor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is subcontractor of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has subcontractor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A subcontractor is someone who enters into a subcontract with the primary contractor.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=subcontractor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>057a7d50-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Engineer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is engineer at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has engineer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contractor is a role in the e.g. person-organisation relationship; that is, the classification term (cfTerm) "Contractor" identified by its cfClassificationIdentifier (a uuid) and reused in e.g. the cfPerson_OrganisationUnit or cfProject_Person link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A person who uses scientific knowledge to solve practical problems.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=engineer</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>b9bd41f0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Administrator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is administrator at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has administrator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, administrator is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Administrator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities (CERIF Task Group). An administrator directly employed by an organisation (RMAS Project).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">An administrator is a person responsible for the performance or management of administrative business operations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Administrator</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An administrator directly employed on an activity or a person not directly involved in the activity but with information related to the activity (e.g. finance, computing, hr), where they are not a contact.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Employment Types; Person Project Engagements; Activity Finance Categories -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers; cfProj_Meas -->
+      <cfClassId>8adcdf20-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Technician</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is technician at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has technician</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, technician is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Technician" identified by its cfClassificationIdentifier (a uuid) and reused inlink entities. (CERIF Task Group) A permanent Research staff. (RMAS project)</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The full economic cost associated with pool technicians used in the activity (Activity Finance Category). Someone, whose duties include the construction, maintenance and operation of the equipment involved in laboratory research; the preparation of samples that constitute the raw material for experiments; the running of those experiments; and the recording, presentation and - on occations - some of the analysis and interpretation of the data that is produced. In undertaking these tasks, technicians work closely with academic researchers and make an indispensible contribution to the production of scientific knowledge, and through formal, and, in particular, informal contributions to the teaching of practical skills, they help to educate students (http://www.kcl.ac.uk/sspp/departments/management/people/academic/lewisgatsbyreport.pdf).</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://www.jcpsg.ac.uk/guidance/</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A technician is someone known for high skill in some intellectual or artistic technique.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=technician</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>ebd55ab0-1cfc-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Researcher</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is researcher at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has researcher</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, researcher is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Researcher" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A researcher is a scientist who devotes himself to doing research (Wordnet). Permanent research, non-teaching staff (RMAS Project).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=researcher</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>04c3f400-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Consultant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is consultant at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has consultant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, consultant is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Consultant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A consultant is an expert who gives advice.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=consultant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Organisation Roles; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_OrgUnit; cfProj_Pers -->
+      <cfClassId>727f6240-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">PhD Student</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is phd student at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has phd student</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, phd is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "PhD" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">Doctor of Philosophy, abbreviated to PhD, or Ph.D. in English-speaking countries, for the Greek διδάκτω�? φιλοσοφίας (Latin philosophiae doctor). Here φιλοσοφία/philosophy, literally translating tο "the love of wisdom", is used in the original Greek sense, loosely meaning "the pursuit of in depth knowledge" and does not refer to the scientific field philosophy.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Doctor_of_Philosophy</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A Phd or doctor's degree; doctorate is usually based on at least 3 years graduate study and a dissertation; the highest earned academic degrees conferred by a university.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=PhD</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements -->
+      <!-- usage with CERIF: cfProj_Pers -->
+      <cfClassId>e7036eeb-aca5-48d6-9ba1-c4c1d8fd96eb</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Investigator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is investigator with</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has investigator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Someone who investigates</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=investigator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements -->
+      <!-- usage with CERIF: cfProj_Pers -->
+      <cfClassId>b0e11470-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Principal Investigator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is principal investigator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has principal investigator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, principal investigator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Principal Investigator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">Principal Investigator is also called Promoter.</cfEx>
+      <cfDef cfLangCode="en" cfTrans="o">A principal investigator (PI) is the lead scientist or engineer for a particular well-defined science (or other research) project, such as a laboratory study or clinical trial. It is often used as a synonym for "head of the laboratory," not just for a particular study. In the context of USA federal funding from agencies such as the NIH or the NSF, the PI is the person who takes direct responsibility for completion of a funded project, directing the research and reporting directly to the funding agency.[1] For small projects (which might involve 1-5 people) the PI is typically the person who conceived of the investigation, but for larger projects the PI may be selected by a team to obtain the best strategic advantage for the project. In the context of a clinical trial a PI may be an academic working with grants from NIH or other funding agencies, or may be effectively a contractor for a pharmaceutical company working on testing the safety and efficacy of new medicines.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Principal_investigator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Person Professional Relationships -->
+      <!-- usage with CERIF: cfProj_Pers; cfPers_Pers -->
+      <cfClassId>bc34dc30-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Co-Investigator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is co-investigator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has co-investigator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, co-investigator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Co-Investigator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A co-investitagor is also called co-promoter (quite often from different organizations). A co-investigator, fellow worker, workfellow (an associate that one works with).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_Proj -->
+      <cfClassId>541b4224-a784-49b7-a341-8275ce874ada</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Collaborator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is collaborator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has collaborator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A person that is formally a member of the project consortium.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_Proj -->
+      <cfClassId>65c14308-310c-4198-be0b-43a6a1697038</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Highly Qualified Personel</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A person whose role on an activity is research and development (e.g. Researcher, PostDoc; PostGrad Research Assistant).</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_Proj -->
+      <cfClassId>2a9173a6-3725-43f3-aed1-1d754b30f57d</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Student</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Somebody undertaking a degree by research.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Person Employment Types; Person Project Engagements -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfPers_OrgUnit; cfPers_Proj -->
+      <cfClassId>eda28bc5-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Supporter</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is supporter of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has supporter</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">The person not directly involved in the activity but contributing to maintaining the infrastructure.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A supporter is someone who supports or champions something.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=supporter</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements -->
+      <!-- usage with CERIF: cfProj_Pers -->
+      <cfClassId>254cb300-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Project Officer</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is project officer of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has project officer</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, project officer is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Project Officer" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A project officer is a person within the funding organsiation responsible for the project.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit -->
+      <cfClassId>c31d3380-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Coordinator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is coordinator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has coordinator</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, coordinator is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Coordinator" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">The lead partner in a consortium.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A coordinator is someone whose task is to see that work goes harmoniously.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=coordinator</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Person Event Involvements -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfPers_Event -->
+      <cfClassId>ddc3dd10-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Participant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is participant in</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has participant</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, participant is a role e.g. in the person-project relationship; that is, the classification term (cfTerm) "Participant" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A participant is someone who takes part in an activity</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=participant</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Event Involvements; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Output Contributions; Person Organisation Roles; Person Project Engagements; Organisation Funding Roles -->
+      <!-- usage with CERIF: cfPers_Event; cfPers_ResPubl; cfPers_ResPat; cfPers_ResProd; cfPers_Event; cfPers_OrgUnit; cfProj_Pers; cfOrgUnit_Fund -->
+      <cfClassId>e4d7b130-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contributor</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CIA project; RMAS Project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contributor to</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contributor</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, contributor is a role in e.g. the person-project relationship; that is, the classification term (cfTerm) "Contributor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Person contributing (in a generic way) before/during/after an event. An entity responsible for making contributions to the resource.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary; http://dublincore.org/documents/dces/#contributor</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contact</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contact of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contact</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">The person to be contacted in a particular circumstance (e.g. finance).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">In CERIF terms, contact is a role in e.g. the person-project, organisation-funding, ... relationship; that is, the classification term (cfTerm) "Contact" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contact is a communicative interaction.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contact</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Output Contributions -->
+      <!-- usage with CERIF: cfProj_Pers; cfProj_OrgUnit; cfOrgUnit_Fund; cfPers_Fund; cfPers_ResPat -->
+      <cfClassId>33551370-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Applicant</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is applicant of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has applicant</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An applicant is an organisation that submits a grant application on behalf of a consortium, partnership or network of participating organisations; the applicant represents and acts on behalf of the group of participating organisation in its relations with the Agency; if the grant application is selected, the Applicant will become the main beneficiary (see Beneficiary definition below) and will sign the grant agreement on behalf of the participating organisations</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">http://eacea.ec.europa.eu/erasmus_mundus/tools/glossary_en.php</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An applicant is also called proposer.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Output Contributions; Person Project Engagements -->
+      <!-- usage with CERIF: cfPers_ResPubl; cfPers_Proj -->
+      <cfClassId>7ef3bfc0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Subject</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is subject of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has subject</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">A person on which an experiment is performed.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Any one of the topics or themes of a work, stated explicitly in the text or title or implicit in its message. In library cataloging, a book or other item is assigned one or more subject headings as access points, to assist users in locating its content by subject. In abstracting and indexing services, the headings assigned to represent the content of a document are called descriptors</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://lu.com/odlis/odlis_s.cfm#subject</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonResearchInfrastructureRoles.xml
+++ b/vocab/xml/PersonResearchInfrastructureRoles.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>3fe69a55-34c3-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Person Research Infrastructure Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfPerson_Equipment; cfPerson_Service, cfPerson_Facility link entities, being thus person infrastructure roles.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Person Project Engagements; Organisation Funding Roles; Person Funding Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfProj_Pers; cfOrgUnit_Fund; cfPers_Fund; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>2af3d7c0-1cfe-11e1-8bc2-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Contact</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is contact of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has contact</cfRoleExprOpp>
+      <cfDescr cfLangCode="en" cfTrans="o">The person to be contacted in a particular circumstance (e.g. finance).</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDescrSrc>
+      <cfEx cfLangCode="en" cfTrans="o">In CERIF terms, contact is a role in e.g. the person-project, organisation-funding, ... relationship; that is, the classification term (cfTerm) "Contact" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A contact is a communicative interaction.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=contact</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Funding Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Fund; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>eda2b2e3-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Responsible</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is responsible for</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has responsible</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A responsible is the agent or cause; worthy of or requiring responsibility or trust; or held accountable.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=responsible;</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Facil; cfOrgUnit_Equip; cfOrgUnit_Srv; cfProj_Facil; cfProj_Equip; cfProj_Srv; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>eda2da00-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">User</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is user of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has user</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">(eg. the Research Organisation)</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>eda2da01-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Staff</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is staff at</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has staff</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PersonTitles.xml
+++ b/vocab/xml/PersonTitles.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+	<cfClassScheme>
+		<cfClassSchemeId>b93fc7ba-90be-4825-a1fd-363bd2fd1432</cfClassSchemeId>
+		<cfName cfLangCode="en" cfTrans="o">Person Titles</cfName>
+		<cfDescr cfLangCode="en" cfTrans="o">The personal honorific titles (may be more than one).</cfDescr>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>8f558c1a-be74-4d3c-8f19-fdd645b61c0a</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Dr</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>bd2600ce-3bcf-4193-be07-8beaa76b91dd</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Miss</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>3bd6c3dd-7132-465e-923b-d7ceeeda93d6</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Mr</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>2e7190cc-51b9-49d3-a11d-bc739e3dabfb</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Mrs</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>09bc5967-6b4c-4815-ac8e-1a5a5eb8ee03</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Ms</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Organisation Roles; Person Titles -->
+			<!-- usage with CERIF: cfPers_OrgUnit, cfPers_Class -->
+			<cfClassId>3bb53320-1cfd-11e1-8bc2-0800200c9a66</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Professor</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+			<cfRoleExpr cfLangCode="en" cfTrans="o">is professor at</cfRoleExpr>
+			<cfRoleExprOpp cfLangCode="en" cfTrans="o">has professor</cfRoleExprOpp>
+			<cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, professor is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Professor" identified by its cfClassificationIdentifier (a uuid) and reused in link entities.</cfDescr>
+			<cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+			<cfDef cfLangCode="en" cfTrans="o">A professor is someone who is a member of the faculty at a college or university.</cfDef>
+			<cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=professor</cfDefSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>27a398fa-0ea6-4445-95de-53a32e839b4d</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Reverend</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>2a5de419-4144-42fe-8e4b-73dca8c54f8d</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Sir</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Organisation Roles; Person Titles -->
+			<!-- usage with CERIF: cPers_OrgUnit; cfPers_Class -->
+			<cfClassId>a27e5ca7-3d20-4272-9054-7db550e2a053</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Associate</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+			<cfRoleExpr cfLangCode="en" cfTrans="o">is associate of</cfRoleExpr>
+			<cfRoleExprOpp cfLangCode="en" cfTrans="o">has associate</cfRoleExprOpp>
+			<cfDescr cfLangCode="en" cfTrans="o">In CERIF terms, associate is a role in e.g. the person-organisation relationship; that is, the classification term (cfTerm) "Associate" identified by its cfClassificationIdentifier (a uuid) and reused in the e.g. cfPerson_OrganisationUnit entity.</cfDescr>
+			<cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+			<cfDef cfLangCode="en" cfTrans="o">An associate is a person with subordinate membership in a society, institution, or commercial enterprise.</cfDef>
+			<cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=associate</cfDefSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>a944b6ae-e2be-40e0-a33e-e5da5db6ea89</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Dame</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>1e83ced2-47e7-4e01-a7b9-ec78291d979c</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Emeritus</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+		<cfClass>
+			<!-- class schemes: Person Titles -->
+			<!-- usage with CERIF: cfPers_Class -->
+			<cfClassId>d0d64e35-d7dd-443d-8d77-96ee4ad8023b</cfClassId>
+			<cfTerm cfLangCode="en" cfTrans="o">Colonel</cfTerm>
+			<cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+		</cfClass>
+	</cfClassScheme>
+	<head xmlns=""/>
+</CERIF>

--- a/vocab/xml/ProjectOutcomeRelations.xml
+++ b/vocab/xml/ProjectOutcomeRelations.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>355408c0-4afa-417d-a7cb-642b74c6dff9</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Project Outcome Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in project initiated results, such as citations or spin-offs, e.g. recorded through the cfProject_OrganisationUnit link entity or with citation counting, being thus project outcome relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Project Outcome Relations -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit -->
+      <cfClassId>eda28bcc-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Spin-Off</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is spin-off from</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has spin-off</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A spin-out, also known as a spin-off or a starburst, refers to a type of corporate action where a company "splits off" sections of itself as a separate business.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://en.wikipedia.org/wiki/Corporate_spin-off</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ProjectOutputRoles.xml
+++ b/vocab/xml/ProjectOutputRoles.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af931-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Project Output Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in a cfProject_ResultPublication link entity - being thus project publication roles.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Project Output Roles; Project Output Roles; Project Output Roles; Project Output Roles -->
+      <!-- usage with CERIF: cfProj_ResPubl; cfProj_ResPat; cfProj_ResProd; cfProj_Event -->
+      <cfClassId>eda2b2d8-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Originator</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is originator of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has originator</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">A originator is someone who creates new things.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=Originator</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ProjectResearchInfrastructureRelations.xml
+++ b/vocab/xml/ProjectResearchInfrastructureRelations.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6df06582-34bd-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Project Research Infrastructure Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfProject_Equipment; cfProject_Service, cfProject_Facility link entities, being thus project infrastructure relation.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Activity Structure; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations; Inter-Output Relations -->
+      <!-- usage with CERIF: cfProj_Proj; cfProj_Equip; cfProj_Facil; cfProj_Srv; cfResPubl_ResProd; cfResPubl_ResPat; cfResPubl_ResPubl; cfResProd_ResProd; cfResPat_ResPat; -->
+      <cfClassId>eda28bc9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Built on</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is built on</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has built</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">Built on - is a form of succession - informally expressed.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Organisation Research Infrastructure Roles; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Person Research Infrastructure Roles; Person Research Infrastructure Roles; Person Research Infrastructure Roles -->
+      <!-- usage with CERIF: cfOrgUnit_Facil; cfOrgUnit_Equip; cfOrgUnit_Srv; cfProj_Facil; cfProj_Equip; cfProj_Srv; cfPers_Facil; cfPers_Equip; cfPers_Srv -->
+      <cfClassId>eda2da00-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">User</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is user of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has user</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">(eg. the Research Organisation)</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations -->
+      <!-- usage with CERIF: cfProj_Facil; cfProj_Equip; cfProj_Srv -->
+      <cfClassId>eda2da02-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Construction</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is constructed from</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has been constructed</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Project Research Infrastructure Relations; Project Research Infrastructure Relations; Project Research Infrastructure Relations; Output Research Infrastructure Relations; Output Research Infrastructure Relations; Output Research Infrastructure Relations -->
+      <!-- usage with CERIF: cfProj_Srv; cfProj_Equip; cfProj_Facil; cfResPat_Facil; cfResPat_Equip; cfResPat_Srv; cfResProd_Facil; cfResProd_Equip; cfResProd_Srv -->
+      <cfClassId>eda2da03-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Development</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is developed by</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has developed</cfRoleExprOpp>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/PublicationStatuses.xml
+++ b/vocab/xml/PublicationStatuses.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>40e90e2f-446d-460a-98e5-5dce57550c48</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Publication Statuses</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The status of the publication in the publishing process.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Publication Statuses -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>1bb29e6d-d282-415f-920d-9b6148933a35</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">In Preparation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A (planned) output.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Publication Statuses -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>1c774414-3a42-4e4c-b3c5-04b89202c40f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Submitted for Consideration</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A final draft submitted for consideration.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Publication Statuses -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>da636eb4-efe2-4112-a4ee-7ce4a99e2374</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">In Press</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An accepted but not yet published output.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Publication Statuses -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>e601872f-4b7e-4d88-929f-7df027b226c9</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Published</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">An output available in the public domain (paid or open access or grey literature, and including but not restricted to "public domain works").</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Publication Statuses -->
+      <!-- usage with CERIF: cfResPubl_Class -->
+      <cfClassId>24906a3a-1edd-40f0-aeec-5f0bf4312086</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Unpublished</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CIA project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A proposed output never put in the public domain.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructure.xml
+++ b/vocab/xml/ResearchInfrastructure.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>dbdd1fdb-128b-414c-ba2b-fa26a25a4bc6</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme defines the CERIF concept of "Research Infrastructure" composed through the link entities cfEquipment_Classification, cfFacility_Classification, cfService_Classification</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure; Research Infrastructure; Research Infrastructure -->
+      <!-- usage with CERIF: cfSrv_Class; cfEquip_Class; cfFacil_Class -->
+      <cfClassId>cf7799ea-3477-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Infrastructure</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Concept; MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of research infrastructure is defined as a term in the vocabulary. A research infrastructure in CERIF terms subsumes the three entities service cfService (cfSrv), equipment cfEquipment (cfEquip) and facility cfFacility (cfFacil); these are logic and physic enitites in the CERIF data model.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">A European Research Infrastructure is a facility or (virtual) platform that provides the scientific community with resources and services to conduct top-level research in their respective fields. These research infrastructures can be single-sited or distributed or an e-infrastructure, and can be part of a national or international network of facilities, or of interconnected scientific instrument networks. The infrastructure should: offer top quality scientific and technological performance, that should be recognised as being of European relevance offer access to scientific users from Europe and beyond through a transparent selection process on the basis of excellence have stable and effective management</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.esf.org/activities/science-policy/research-infrastructures/meril-mapping-of-the-european-research-infrastructure-landscape/what-is-meant-by-research-infrastructures.html</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureAccess.xml
+++ b/vocab/xml/ResearchInfrastructureAccess.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>4490bcae-1632-460d-947c-c230130c013b</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Access</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable with the cfResultPublication_Equipment; cfResultPublication_Facility; and cfResultPublication_Service link entities, being thus the documents related to access policy or terms and conditions of the Research Infrastructure.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Access; Research Infrastructure Access; Research Infrastructure Access -->
+      <!-- usage with CERIF: cfResPubl_Equip; cfResPubl_Facil; cfResPubl_Srv -->
+      <cfClassId>eda2b2dd-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Access Policy Document</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is equipment access policy document for</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has equipment access policy document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The document specifying the access policy for the equipment, facility or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Access; Research Infrastructure Access; Research Infrastructure Access -->
+      <!-- usage with CERIF: cfResPubl_Equip; cfResPubl_Facil; cfResPubl_Srv -->
+      <cfClassId>80be3ed3-5677-4676-b466-fa9f61d8af42</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Access Terms and Conditions</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is terms and conditions document for</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has terms and conditions document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The document specifying the access terms and conditions for the equipment, facility or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureCostings.xml
+++ b/vocab/xml/ResearchInfrastructureCostings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>1c603df8-6949-4f07-bbc3-3388df7dcd2c</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Costings</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfFacility_Measurement; cfEquipment_Measurement; cfService_Measurement link entities, being thus research infrastructure costing.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Costings; Research Infrastructure Costings; Research Infrastructure Costings -->
+      <!-- usage with CERIF: cfFacil_Meas; cfEquip_Meas; cfSrv_Meas -->
+      <cfClassId>eda2da08-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Construction Costs</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Costings; Research Infrastructure Costings; Research Infrastructure Costings -->
+      <!-- usage with CERIF: cfFacil_Meas; cfEquip_Meas; cfSrv_Meas -->
+      <cfClassId>eda2da09-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Design Costs</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Costings; Research Infrastructure Costings; Research Infrastructure Costings -->
+      <!-- usage with CERIF: cfFacil_Meas; cfEquip_Meas; cfSrv_Meas -->
+      <cfClassId>eda2da0a-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Operating Costs</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureFundingRoles.xml
+++ b/vocab/xml/ResearchInfrastructureFundingRoles.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>3fe69a58-34c3-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Funding Roles</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfFunding_Equipment; cfFunding_Service, cfFunding_Facility link entities, being thus funding infrastructure roles.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Inter-Organisational Structure; Organisation Project Engagements; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Organisation Output Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Output Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles; Research Infrastructure Funding Roles -->
+      <!-- usage with CERIF: cfOrgUnit_OrgUnit; cfProj_OrgUnit; cfOrgUnit_ResPubl; cfOrgUnit_ResPat; cfOrgUnit_ResProd; cfOrgUnit_Event; cfResPubl_Fund; cfResPat_Fund; cfResProd_Fund; cfEvent_Fund; cfFacil_Fund; cfEquip_Fund; cfSrv_Fund -->
+      <cfClassId>eda28bc0-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Funder</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; RMAS project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is funder of</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has funder</cfRoleExprOpp>
+      <cfEx cfLangCode="en" cfTrans="o">An organisation that provides funding towards the cost of an activity.</cfEx>
+      <cfExSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfExSrc>
+      <cfDef cfLangCode="en" cfTrans="o">Individual or organization financing a part or all of a project's cost as a grant, investment, or loan.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://www.businessdictionary.com/definition/funder.html</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureRelations.xml
+++ b/vocab/xml/ResearchInfrastructureRelations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>4c2f217d-98ad-4c49-bbb0-399e28d7a8c9</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Relations</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfFacility_Service; cfEquipment_Service; cfFacility_Equipment link entities, being thus research infrastructure relations.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Relations; Research Infrastructure Relations; Research Infrastructure Relations -->
+      <!-- usage with CERIF: cfFacil_Srv; cfEquip_Srv; cfFacil_Equip -->
+      <cfClassId>eda2da07-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Provision</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in state of provision</cfRoleExpr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureStatuses.xml
+++ b/vocab/xml/ResearchInfrastructureStatuses.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>1eb17479-09de-49b8-9fed-1a54d697ea1c</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Statuses</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfEquipment_Classification; cfFacility_Classification; cfService_Classification link entities, being thus research infrastructure states.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Statuses; Research Infrastructure Statuses; Research Infrastructure Statuses -->
+      <!-- usage with CERIF: cfFacil_Class; cfEquip_Class; cfSrv_Class -->
+      <cfClassId>eda2da04-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Under Construction</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in state of under construction</cfRoleExpr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Statuses; Research Infrastructure Statuses; Research Infrastructure Statuses -->
+      <!-- usage with CERIF: cfFacil_Class; cfEquip_Class; cfSrv_Class -->
+      <cfClassId>eda2da05-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Being Upgraded</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in state of being upgraded</cfRoleExpr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Statuses; Research Infrastructure Statuses; Research Infrastructure Statuses -->
+      <!-- usage with CERIF: cfFacil_Class; cfEquip_Class; cfSrv_Class -->
+      <cfClassId>eda2da06-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">In Operation</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is in state of operation</cfRoleExpr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureTypes.xml
+++ b/vocab/xml/ResearchInfrastructureTypes.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>759af93d-34ae-11e1-b86c-0800200c9a66</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Types</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable in the cfEquipment_Classification, cfService_Classification, cfFacility_Classification link entities, being thus infrastructure types.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Types; Research Infrastructure Types; Research Infrastructure Types -->
+      <!-- usage with CERIF: cfSrv_Class; cfFacil_Class; cfEquip_Class -->
+      <cfClassId>eda2d9f9-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Distributed</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfDescr cfLangCode="en" cfTrans="o">A distributed RI is constituted by geographically distributed implementations/facilities but managed by a single body. Thus, a distributed RI is thus considered as a single RI, modelled in CERIF as a tree of facilities connected to the Facility entity representing the entire RI via recursive cfFacility_Facility relationships with appropriate semantics (e.g. isPartOf) while the RI is connected with its managing body through the cfOrgUnit_Facil link entity.</cfDescr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Types; Research Infrastructure Types; Research Infrastructure Types -->
+      <!-- usage with CERIF: cfSrv_Class; cfFacil_Class; cfEquip_Class -->
+      <cfClassId>eda2d9fa-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Network</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">A network of RIs comprises several RIs connected in some respect, but each one with its own governance/management body. The relationships between RIs in a network are modelled in CERIF using the CERIF Semantic Layer reference from within the cfFacil_Class link entity (Class=Network, role expression is a network).</cfDescr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Types; Research Infrastructure Types; Research Infrastructure Types -->
+      <!-- usage with CERIF: cfSrv_Class; cfFacil_Class; cfEquip_Class -->
+      <cfClassId>eda2d9fb-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Virtual</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">A virtual RI is defined as e-infrastructure, either a distributed e�?infrastructure that connects several RIs (databases, HP computers, facilities, etc) or a single�?sited electronic RI (e-library, e-archive, data repository, etc).  </cfDescr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Types; Research Infrastructure Types; Research Infrastructure Types -->
+      <!-- usage with CERIF: cfSrv_Class; cfFacil_Class; cfEquip_Class -->
+      <cfClassId>eda2d9fc-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Cluster</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">A cluster is a grouping of RIs based on certain similarities (scientific domain, geographical region). A cluster of RIs may be supported in some way or funded, e.g. by industry entities. A cluster is modelled in CERIF as a virtual organisation through the cfOrgUnit entity connected with the individual RIs belonging to the cluster with a cfOrgUnit_Facil link entity.</cfDescr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Types; Research Infrastructure Types; Research Infrastructure Types -->
+      <!-- usage with CERIF: cfSrv_Class; cfFacil_Class; cfEquip_Class -->
+      <cfClassId>eda2d9fd-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Single location</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfExSrc cfLangCode="en" cfTrans="o">MERIL project</cfExSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchInfrastructureUsage.xml
+++ b/vocab/xml/ResearchInfrastructureUsage.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>47761818-0e55-41a6-a21e-1e72f9a8922e</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Infrastructure Usage</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme contains CERIF vocabulary terms applicable with the cfResultPublication_Equipment; cfResultPublication_Facility; and cfResultPublication_Service link entities, being thus the documents related to usage of the Research Infrastructure.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Infrastructure Usage; Research Infrastructure Usage; Research Infrastructure Usage -->
+      <!-- usage with CERIF: cfResPubl_Equip; cfResPubl_Facil; cfResPubl_Srv -->
+      <cfClassId>eda2b2de-34c5-11e1-b86c-0800200c9a66</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Usage Document</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">MERIL project</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is equipment usage document for</cfRoleExpr>
+      <cfRoleExprOpp cfLangCode="en" cfTrans="o">has equipment usage document</cfRoleExprOpp>
+      <cfDef cfLangCode="en" cfTrans="o">The document specifying the usage for the equipment, facility or service.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/ResearchOutput.xml
+++ b/vocab/xml/ResearchOutput.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>6832797c-2f56-4336-b4ff-dc0ba2275dfa</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Research Output</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">This scheme defines the CERIF concept of "Research Output" composed through the link entities cfResultPublication_Classification, cfResultPatent_Classification, cfResultProduct_Classification</cfDescr>
+    <cfClass>
+      <!-- class schemes: Research Output; Research Output; Research Output -->
+      <!-- usage with CERIF: cfResPubl_Class; cfResPat_Class; cfResProd_Class; cfEvent_Class -->
+      <cfClassId>627e286f-a8ae-46c6-891e-0218e6b2f1a8</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Research Output</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">CERIF Task Group; HEFCE REF2014 Output Information Requirements; RMAS Vocabulary; CASRAI Dictionary</cfTermSrc>
+      <cfRoleExpr cfLangCode="en" cfTrans="o">is a</cfRoleExpr>
+      <cfDescr cfLangCode="en" cfTrans="o">In CERIF, the concept of research output is defined as a term in the vocabulary. Research output in CERIF terms subsumes results such as publications cfResultPublication (cfResPubl), patent cfResultPatent (cfResPat) and product cfResultProduct (cfResProd); these are logic and physic enitites in the CERIF data model.</cfDescr>
+      <cfDescrSrc cfLangCode="en" cfTrans="o">CERIF Task Group</cfDescrSrc>
+      <cfDef cfLangCode="en" cfTrans="o">The act of becoming formally connected or joined; a social or business relationship.</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">http://wordnetweb.princeton.edu/perl/webwn?s=affiliation</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>

--- a/vocab/xml/VerificationStatuses.xml
+++ b/vocab/xml/VerificationStatuses.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CERIF xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:xmlns:org:eurocris:cerif-1.5-1 http://www.eurocris.org/Uploads/Web%20pages/CERIF-1.5/CERIF_1.5_1.xsd" release="1.5" date="2012-10-02" sourceDatabase="CERIF1.5_Semantics.xls">
+  <cfClassScheme>
+    <cfClassSchemeId>2ad984e8-33ae-4f0b-927e-d292c28750e3</cfClassSchemeId>
+    <cfName cfLangCode="en" cfTrans="o">Verification Statuses</cfName>
+    <cfDescr cfLangCode="en" cfTrans="o">The state of verification, deduced from a date-time (e.g. for outputs) where raw data may have been imported from external sources or for information about staff which might be re-validated on annual basis.</cfDescr>
+    <cfClass>
+      <!-- class schemes: Verification Statuses -->
+      <!-- usage with CERIF: cfPers_Class; cfProj_Class; cfResPubl_Class; cfResProd_Class; cfResPat_Class; cfFund_Class; cfMeas_Class -->
+      <cfClassId>c3c8c96f-cc0f-47e6-9c6d-4f86949ab984</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Checked</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">checked</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+    <cfClass>
+      <!-- class schemes: Verification Statuses -->
+      <!-- usage with CERIF: cfPers_Class; cfProj_Class; cfResPubl_Class; cfResProd_Class; cfResPat_Class; cfFund_Class; cfMeas_Class -->
+      <cfClassId>9b5e9d79-c332-40cb-b888-8a37bdef9f1f</cfClassId>
+      <cfTerm cfLangCode="en" cfTrans="o">Unchecked</cfTerm>
+      <cfTermSrc cfLangCode="en" cfTrans="o">RMAS project</cfTermSrc>
+      <cfDef cfLangCode="en" cfTrans="o">not yet checked</cfDef>
+      <cfDefSrc cfLangCode="en" cfTrans="o">RMAS Vocabulary</cfDefSrc>
+    </cfClass>
+  </cfClassScheme>
+<head xmlns=""/></CERIF>


### PR DESCRIPTION
This is the result of the XML transformation of the CERIF 1.5 semantics, splitted into several files (one per vocabulary).
Configuration allows to serve XML or RDF (default) depending on the content expected by the request.