### PR TITLE
disable content negociation if no vocabulary requested

### DIFF
--- a/vocab/.htaccess
+++ b/vocab/.htaccess
@@ -6,6 +6,10 @@ AddType application/rdf+xml .rdf
 RewriteEngine On
 RewriteBase /vocab
 
+#if no vocabulary requested, just list the folder (needs +Indexes on the folder)
+RewriteCond %{REQUEST_URI} ^/vocab/$
+RewriteRule (.*) $1 [L]
+
 #if already in final folders, stop redirecting
 RewriteCond %{REQUEST_URI} /(html|xml|rdf)/
 RewriteRule (.*) $1 [L]


### PR DESCRIPTION
To allow vocab to be listed, apache configuration also needs to be updated for the vocab folder with the following settings:

`Options -MultiViews +Indexes`
`IndexOptions FancyIndexing HTMLTable`

Note: `Options -Multiviews` should already have been configured, so just need to be updated